### PR TITLE
feat: gallery upload fix, homepage product interactions, admin customer delete, mobile responsiveness

### DIFF
--- a/src/__tests__/actions/gallery.test.ts
+++ b/src/__tests__/actions/gallery.test.ts
@@ -1,0 +1,172 @@
+import { createGalleryItem, getGalleryItems, updateGalleryItem, deleteGalleryItem } from '@/app/actions/gallery'
+
+const mockGetUser = jest.fn()
+const mockStorageUpload = jest.fn()
+const mockStorageRemove = jest.fn()
+const mockGetPublicUrl = jest.fn()
+
+function makeGalleryQuery(result: any) {
+  return {
+    select: jest.fn(() => ({
+      eq: jest.fn(() => ({
+        order: jest.fn(() => Promise.resolve(result)),
+        single: jest.fn(() => Promise.resolve(result)),
+      })),
+      single: jest.fn(() => Promise.resolve(result)),
+      order: jest.fn(() => Promise.resolve(result)),
+    })),
+    insert: jest.fn(() => ({
+      select: jest.fn(() => ({
+        single: jest.fn(() => Promise.resolve(result)),
+      })),
+    })),
+    update: jest.fn(() => ({
+      eq: jest.fn(() => ({
+        select: jest.fn(() => ({
+          single: jest.fn(() => Promise.resolve(result)),
+        })),
+      })),
+    })),
+    delete: jest.fn(() => ({
+      eq: jest.fn(() => Promise.resolve({ error: null })),
+    })),
+  }
+}
+
+let galleryQueryResult: any = { data: [], error: null }
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: jest.fn(() => makeGalleryQuery(galleryQueryResult)),
+    })
+  ),
+  createAdminClient: jest.fn(() => ({
+    storage: {
+      from: jest.fn(() => ({
+        upload: mockStorageUpload,
+        remove: mockStorageRemove,
+        getPublicUrl: mockGetPublicUrl,
+      })),
+    },
+    from: jest.fn(() => makeGalleryQuery(galleryQueryResult)),
+  })),
+}))
+
+const validFile = new File(['fake-image-content'], 'test-artwork.jpg', { type: 'image/jpeg' })
+
+function buildFormData(file: File | null, overrides: Record<string, any> = {}) {
+  const fd = new FormData()
+  if (file) fd.append('file', file)
+  fd.append('meta', JSON.stringify({
+    title: 'Test Artwork',
+    medium: 'Oil on Canvas',
+    size: '16x20 in',
+    year: 2024,
+    category: 'portrait',
+    description: 'A beautiful painting',
+    featured: false,
+    ...overrides,
+  }))
+  return fd
+}
+
+const mockCreatedRow = {
+  id: 'gallery-uuid-1',
+  title: 'Test Artwork',
+  medium: 'Oil on Canvas',
+  size: '16x20 in',
+  year: 2024,
+  category: 'portrait',
+  image_url: 'https://example.supabase.co/storage/v1/object/public/gallery-images/gallery/test.jpg',
+  storage_path: 'gallery/test.jpg',
+  description: 'A beautiful painting',
+  featured: false,
+  sort_order: 0,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'admin-uuid' } } })
+  mockStorageUpload.mockResolvedValue({ error: null })
+  mockStorageRemove.mockResolvedValue({ error: null })
+  mockGetPublicUrl.mockReturnValue({ data: { publicUrl: mockCreatedRow.image_url } })
+  galleryQueryResult = { data: mockCreatedRow, error: null }
+})
+
+describe('createGalleryItem', () => {
+  it('uploads a valid artwork successfully', async () => {
+    const result = await createGalleryItem(buildFormData(validFile))
+    expect(result.title).toBe('Test Artwork')
+    expect(result.image_url).toBe(mockCreatedRow.image_url)
+    expect(mockStorageUpload).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects when no file is provided', async () => {
+    await expect(createGalleryItem(buildFormData(null))).rejects.toThrow('No image provided')
+  })
+
+  it('rejects unsupported file extensions', async () => {
+    const badFile = new File(['x'], 'malware.exe', { type: 'application/x-msdownload' })
+    await expect(createGalleryItem(buildFormData(badFile))).rejects.toThrow('Unsupported file type')
+  })
+
+  it('rejects files that are too large', async () => {
+    const bigFile = new File(['x'.repeat(11 * 1024 * 1024)], 'huge.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(bigFile, 'size', { value: 11 * 1024 * 1024 })
+    await expect(createGalleryItem(buildFormData(bigFile))).rejects.toThrow('File is too large')
+  })
+
+  it('rejects when title is missing', async () => {
+    await expect(createGalleryItem(buildFormData(validFile, { title: '' }))).rejects.toThrow('Title is required.')
+  })
+
+  it('rejects when category is missing', async () => {
+    await expect(createGalleryItem(buildFormData(validFile, { category: '' }))).rejects.toThrow('Category is required.')
+  })
+
+  it('handles storage upload failure', async () => {
+    mockStorageUpload.mockResolvedValueOnce({ error: { message: 'Bucket not found' } })
+    await expect(createGalleryItem(buildFormData(validFile))).rejects.toThrow('File upload failed')
+  })
+
+  it('handles DB insert failure and cleans up storage', async () => {
+    galleryQueryResult = { data: null, error: { message: 'insert error' } }
+    await expect(createGalleryItem(buildFormData(validFile))).rejects.toThrow('Failed to save gallery item')
+    expect(mockStorageRemove).toHaveBeenCalled()
+  })
+
+  it('throws when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } })
+    await expect(createGalleryItem(buildFormData(validFile))).rejects.toThrow('Not authenticated')
+  })
+})
+
+describe('getGalleryItems', () => {
+  it('returns gallery items', async () => {
+    galleryQueryResult = { data: [mockCreatedRow], error: null }
+    const items = await getGalleryItems()
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('Test Artwork')
+  })
+})
+
+describe('updateGalleryItem', () => {
+  it('updates item metadata', async () => {
+    const updated = { ...mockCreatedRow, title: 'Updated Title' }
+    galleryQueryResult = { data: updated, error: null }
+    const result = await updateGalleryItem('gallery-uuid-1', { title: 'Updated Title' })
+    expect(result.title).toBe('Updated Title')
+  })
+})
+
+describe('deleteGalleryItem', () => {
+  it('deletes item and cleans up storage', async () => {
+    galleryQueryResult = { data: mockCreatedRow, error: null }
+    await expect(deleteGalleryItem('gallery-uuid-1')).resolves.toBeUndefined()
+    expect(mockStorageRemove).toHaveBeenCalledWith([mockCreatedRow.storage_path])
+  })
+})

--- a/src/__tests__/actions/uploads.test.ts
+++ b/src/__tests__/actions/uploads.test.ts
@@ -1,19 +1,52 @@
-/**
- * Tests for uploadFile — validates server-side file validation,
- * including type checking, size limits, and error handling.
- */
-
-import { uploadFile } from '@/app/actions/uploads'
+import { uploadFile, linkUploadToOrderItem, getUploadsByOrder, getAdminUploadsForOrder } from '@/app/actions/uploads'
 import { ERR } from '@/lib/errorMessages'
 
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }))
 
-// ─── Mock Supabase ────────────────────────────────────────────────────────
-
-const mockGetUser = jest.fn(() => Promise.resolve({ data: { user: { id: 'user-uuid-1' } } }))
+// --- jest.fn() mocks for createClient paths (captured by closure in mock factory) ---
+const mockGetUser = jest.fn()
 const mockStorageUpload = jest.fn()
 const mockCreateSignedUrl = jest.fn()
 const mockUploadsInsert = jest.fn()
+const mockUploadUpdate = jest.fn()
+
+// --- Query result holders (re-assigned per test) ---
+type QueryResult = { data: any[]; error: null }
+
+let orderItemsResult: QueryResult = { data: [], error: null }
+let uploadsResult: QueryResult = { data: [], error: null }
+let paymentsResult: QueryResult = { data: [], error: null }
+
+// --- Query-builder helpers (capture the let variables by closure) ---
+function buildOrderItemsQuery() {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => Promise.resolve(orderItemsResult),
+      }),
+    }),
+  }
+}
+
+function buildUploadsQuery() {
+  return {
+    select: () => ({
+      in: () => ({
+        order: () => Promise.resolve(uploadsResult),
+      }),
+    }),
+  }
+}
+
+function buildPaymentsQuery() {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => Promise.resolve(paymentsResult),
+      }),
+    }),
+  }
+}
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(() =>
@@ -26,19 +59,25 @@ jest.mock('@/lib/supabase/server', () => ({
         })),
       },
       from: jest.fn((table: string) => {
-        if (table === 'uploads') return { insert: mockUploadsInsert }
+        if (table === 'uploads') return { insert: mockUploadsInsert, update: () => ({ eq: mockUploadUpdate }) }
+        if (table === 'order_items') return { select: () => buildOrderItemsQuery().select() }
         return {}
       }),
     })
   ),
+  createAdminClient: jest.fn(() => ({
+    from: jest.fn((table: string) => {
+      if (table === 'order_items') return buildOrderItemsQuery()
+      if (table === 'uploads') return buildUploadsQuery()
+      if (table === 'payments') return buildPaymentsQuery()
+      return { select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) }) }
+    }),
+  })),
 }))
-
-// ─── Test data ────────────────────────────────────────────────────────────
 
 const validFormData = (name: string, type: string, size: number) => {
   const fd = new FormData()
   fd.append('file', new File(['test'], name, { type }))
-  // Override size since File constructor doesn't always respect it
   Object.defineProperty(fd.get('file'), 'size', { value: size })
   return fd
 }
@@ -55,8 +94,6 @@ function formDataFromFile(file: File): FormData {
   return fd
 }
 
-// ─── Setup ────────────────────────────────────────────────────────────────
-
 const mockUploadRow = {
   id: 'upload-uuid-1',
   user_id: 'user-uuid-1',
@@ -71,6 +108,7 @@ const mockUploadRow = {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-uuid-1' } } })
   mockStorageUpload.mockResolvedValue({ error: null })
   mockCreateSignedUrl.mockResolvedValue({ data: { signedUrl: 'https://example.com/signed-url' }, error: null })
   mockUploadsInsert.mockReturnValue({
@@ -78,37 +116,35 @@ beforeEach(() => {
       single: jest.fn(() => Promise.resolve({ data: mockUploadRow, error: null })),
     })),
   })
+  mockUploadUpdate.mockResolvedValue({ error: null })
+  orderItemsResult = { data: [{ id: 'item-1' }], error: null }
+  uploadsResult = { data: [], error: null }
+  paymentsResult = { data: [], error: null }
 })
-
-// ─── Tests ────────────────────────────────────────────────────────────────
 
 describe('uploadFile — server-side file validation', () => {
   it('rejects files with no extension', async () => {
     const file = createMockFile('receipt', 'image/jpeg', 1024)
     Object.defineProperty(file, 'name', { value: 'receipt' })
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_INVALID_TYPE)
   })
 
   it('rejects unsupported file extensions', async () => {
     const file = createMockFile('receipt.exe', 'application/x-msdownload', 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_INVALID_TYPE)
   })
 
   it('rejects files that are too large', async () => {
     const file = createMockFile('receipt.jpg', 'image/jpeg', 11 * 1024 * 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_TOO_LARGE)
   })
 
   it('accepts valid JPG files', async () => {
     const file = createMockFile('receipt.jpg', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     const result = await uploadFile(fd, 'payment_receipt')
     expect(result.file_url).toBe('https://example.com/signed-url')
   })
@@ -116,7 +152,6 @@ describe('uploadFile — server-side file validation', () => {
   it('accepts valid PNG files', async () => {
     const file = createMockFile('receipt.png', 'image/png', 1024)
     const fd = formDataFromFile(file)
-
     const result = await uploadFile(fd, 'payment_receipt')
     expect(result.file_url).toBe('https://example.com/signed-url')
   })
@@ -124,7 +159,6 @@ describe('uploadFile — server-side file validation', () => {
   it('accepts valid PDF files', async () => {
     const file = createMockFile('receipt.pdf', 'application/pdf', 1024)
     const fd = formDataFromFile(file)
-
     const result = await uploadFile(fd, 'payment_receipt')
     expect(result.file_url).toBe('https://example.com/signed-url')
   })
@@ -132,13 +166,11 @@ describe('uploadFile — server-side file validation', () => {
   it('rejects files with .exe extension even with valid MIME type', async () => {
     const file = createMockFile('receipt.exe', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_INVALID_TYPE)
   })
 
   it('throws error when no file is provided', async () => {
     const emptyFd = new FormData()
-
     await expect(uploadFile(emptyFd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_NO_FILE)
   })
 
@@ -146,7 +178,6 @@ describe('uploadFile — server-side file validation', () => {
     ;(mockGetUser as jest.Mock).mockResolvedValueOnce({ data: { user: null } })
     const file = createMockFile('receipt.jpg', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow('Not authenticated')
   })
 })
@@ -155,9 +186,7 @@ describe('uploadFile — storage and DB recording', () => {
   it('uploads to correct bucket and creates DB record', async () => {
     const file = createMockFile('receipt.jpg', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     const result = await uploadFile(fd, 'payment_receipt')
-
     expect(mockStorageUpload).toHaveBeenCalled()
     expect(mockCreateSignedUrl).toHaveBeenCalled()
     expect(mockUploadsInsert).toHaveBeenCalled()
@@ -168,7 +197,6 @@ describe('uploadFile — storage and DB recording', () => {
     mockStorageUpload.mockResolvedValueOnce({ error: { message: 'Storage full' } })
     const file = createMockFile('receipt.jpg', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_FAILED)
   })
 
@@ -176,7 +204,98 @@ describe('uploadFile — storage and DB recording', () => {
     mockCreateSignedUrl.mockResolvedValueOnce({ data: null, error: null })
     const file = createMockFile('receipt.jpg', 'image/jpeg', 1024)
     const fd = formDataFromFile(file)
-
     await expect(uploadFile(fd, 'payment_receipt')).rejects.toThrow(ERR.UPLOAD_URL_FAILED)
+  })
+})
+
+describe('linkUploadToOrderItem', () => {
+  it('links a single upload to an order item', async () => {
+    await expect(linkUploadToOrderItem('upload-id-1', 'item-id-1')).resolves.toBeUndefined()
+  })
+
+  it('supports linking multiple uploads to their respective items', async () => {
+    await linkUploadToOrderItem('upload-id-1', 'item-id-1')
+    await linkUploadToOrderItem('upload-id-2', 'item-id-2')
+    await linkUploadToOrderItem('upload-id-3', 'item-id-3')
+    expect(mockUploadUpdate).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when update fails', async () => {
+    mockUploadUpdate.mockResolvedValueOnce({ error: { message: 'DB error' } })
+    await expect(linkUploadToOrderItem('upload-id-1', 'item-id-1')).rejects.toThrow('Failed to link upload to order item')
+  })
+})
+
+describe('getUploadsByOrder', () => {
+  it('returns empty array when no items found', async () => {
+    orderItemsResult = { data: [], error: null }
+    const result = await getUploadsByOrder('order-1')
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when user not authenticated', async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } } as any)
+    const result = await getUploadsByOrder('order-1')
+    expect(result).toEqual([])
+  })
+})
+
+describe('getAdminUploadsForOrder', () => {
+  const mockOrderItems = [
+    { id: 'item-1', item_type: 'artwork' as const, artwork_type: 'custom_artwork' as const, item_subtotal: 25000, size_label: '12x16', canvas_option: 'Normal', frame_option: null, glass_option: null, base_price: 20000, canvas_price: 5000, frame_price: 0, glass_price: 0, quantity: 1, created_at: '2024-01-15', order_id: 'order-1', product_id: null, width_inches: null, height_inches: null, area_sqin: null, write_up_type: null, write_up_content: null },
+    { id: 'item-2', item_type: 'artwork' as const, artwork_type: 'photo_enlargement' as const, item_subtotal: 15000, size_label: '8x10', canvas_option: null, frame_option: null, glass_option: null, base_price: 15000, canvas_price: 0, frame_price: 0, glass_price: 0, quantity: 1, created_at: '2024-01-15', order_id: 'order-1', product_id: null, width_inches: null, height_inches: null, area_sqin: null, write_up_type: null, write_up_content: null },
+  ]
+  const mockUploadsItem1 = [
+    { id: 'up-1', user_id: 'u1', order_item_id: 'item-1', file_name: 'ref1.jpg', storage_path: 'u1/ref1.jpg', file_url: 'https://example.com/ref1', file_type: 'artwork_reference', file_size: 1024, created_at: '2024-01-15' },
+    { id: 'up-2', user_id: 'u1', order_item_id: 'item-1', file_name: 'ref2.jpg', storage_path: 'u1/ref2.jpg', file_url: 'https://example.com/ref2', file_type: 'artwork_reference', file_size: 2048, created_at: '2024-01-15' },
+  ]
+  const mockUploadsItem2 = [
+    { id: 'up-3', user_id: 'u1', order_item_id: 'item-2', file_name: 'enlarge.jpg', storage_path: 'u1/enlarge.jpg', file_url: 'https://example.com/enlarge', file_type: 'artwork_reference', file_size: 1024, created_at: '2024-01-15' },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-uuid-1' } } })
+    orderItemsResult = { data: mockOrderItems, error: null }
+    uploadsResult = { data: [...mockUploadsItem1, ...mockUploadsItem2], error: null }
+    paymentsResult = { data: [], error: null }
+  })
+
+  it('groups uploads by order item', async () => {
+    const result = await getAdminUploadsForOrder('order-1')
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0].uploads).toHaveLength(2)
+    expect(result.items[1].uploads).toHaveLength(1)
+  })
+
+  it('maps each upload to the correct order item', async () => {
+    const result = await getAdminUploadsForOrder('order-1')
+    expect(result.items[0].uploads[0].id).toBe('up-1')
+    expect(result.items[0].uploads[1].id).toBe('up-2')
+    expect(result.items[1].uploads[0].id).toBe('up-3')
+  })
+
+  it('returns empty uploads array for items without uploads', async () => {
+    uploadsResult = { data: [], error: null }
+    const result = await getAdminUploadsForOrder('order-1')
+    expect(result.items[0].uploads).toEqual([])
+    expect(result.items[1].uploads).toEqual([])
+  })
+
+  it('returns empty items for empty orders', async () => {
+    orderItemsResult = { data: [], error: null }
+    const result = await getAdminUploadsForOrder('order-1')
+    expect(result.items).toEqual([])
+    expect(result.paymentReceipts).toEqual([])
+  })
+
+  it('includes payment receipts when available', async () => {
+    const mockPayments = [
+      { id: 'pay-1', order_id: 'order-1', user_id: 'u1', amount: 25000, payment_type: 'partial', receipt_url: 'https://example.com/receipt1', status: 'verified', verified_by: null, verified_at: null, rejection_reason: null, created_at: '2024-01-15' },
+    ]
+    paymentsResult = { data: mockPayments, error: null }
+    const result = await getAdminUploadsForOrder('order-1')
+    expect(result.paymentReceipts).toHaveLength(1)
+    expect(result.paymentReceipts[0].receipt_url).toBe('https://example.com/receipt1')
   })
 })

--- a/src/__tests__/components/ConfirmDeleteModal.test.tsx
+++ b/src/__tests__/components/ConfirmDeleteModal.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ConfirmDeleteModal from '@/components/ui/ConfirmDeleteModal'
+
+describe('ConfirmDeleteModal', () => {
+  const defaultProps = {
+    title: 'Delete User',
+    message: 'This action cannot be undone.',
+    detailLines: [
+      { label: 'Name', value: 'Jane Doe' },
+      { label: 'Email', value: 'jane@test.com' },
+    ],
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders title and message', () => {
+    render(<ConfirmDeleteModal {...defaultProps} />)
+    expect(screen.getByText('Delete User')).toBeInTheDocument()
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument()
+  })
+
+  it('renders detail lines', () => {
+    render(<ConfirmDeleteModal {...defaultProps} />)
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('jane@test.com')).toBeInTheDocument()
+  })
+
+  it('renders confirm and cancel buttons', () => {
+    render(<ConfirmDeleteModal {...defaultProps} />)
+    expect(screen.getByTestId('confirm-delete-confirm')).toHaveTextContent('Delete')
+    expect(screen.getByTestId('confirm-delete-cancel')).toHaveTextContent('Cancel')
+  })
+
+  it('calls onConfirm when confirm button clicked', () => {
+    const onConfirm = jest.fn()
+    render(<ConfirmDeleteModal {...defaultProps} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when cancel button clicked', () => {
+    const onCancel = jest.fn()
+    render(<ConfirmDeleteModal {...defaultProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('confirm-delete-cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when backdrop clicked', () => {
+    const onCancel = jest.fn()
+    render(<ConfirmDeleteModal {...defaultProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('confirm-delete-backdrop'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows loading state on confirm button', () => {
+    render(<ConfirmDeleteModal {...defaultProps} loading={true} />)
+    expect(screen.getByTestId('confirm-delete-confirm')).toHaveTextContent('Deleting…')
+    expect(screen.getByTestId('confirm-delete-confirm')).toBeDisabled()
+    expect(screen.getByTestId('confirm-delete-cancel')).toBeDisabled()
+  })
+
+  it('shows error message when provided', () => {
+    render(<ConfirmDeleteModal {...defaultProps} error="Failed to delete." />)
+    expect(screen.getByTestId('confirm-delete-error')).toHaveTextContent('Failed to delete.')
+  })
+
+  it('disables backdrop click when loading', () => {
+    const onCancel = jest.fn()
+    render(<ConfirmDeleteModal {...defaultProps} loading={true} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('confirm-delete-backdrop'))
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('renders custom confirm label', () => {
+    render(<ConfirmDeleteModal {...defaultProps} confirmLabel="Remove User" />)
+    expect(screen.getByTestId('confirm-delete-confirm')).toHaveTextContent('Remove User')
+  })
+
+  it('renders custom cancel label', () => {
+    render(<ConfirmDeleteModal {...defaultProps} cancelLabel="Go Back" />)
+    expect(screen.getByTestId('confirm-delete-cancel')).toHaveTextContent('Go Back')
+  })
+
+  it('sets role="alertdialog" and aria-modal="true"', () => {
+    render(<ConfirmDeleteModal {...defaultProps} />)
+    const dialog = screen.getByRole('alertdialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-label', 'Delete User')
+  })
+})

--- a/src/__tests__/components/HomeProductInteraction.test.tsx
+++ b/src/__tests__/components/HomeProductInteraction.test.tsx
@@ -1,0 +1,416 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HomeProductCard from '@/app/(public)/_components/HomeProductCard'
+import ProductQuickViewModal from '@/app/(public)/_components/ProductQuickViewModal'
+import HomeProductSection from '@/app/(public)/_components/HomeProductSection'
+import type { Database } from '@/lib/types/database'
+
+type Product = Database['public']['Tables']['products']['Row']
+
+const makeProduct = (overrides: Partial<Product> = {}): Product => ({
+  id: '1',
+  name: 'Test Print',
+  slug: 'test-print',
+  description: 'A nice portrait print on premium paper.',
+  price: 15000,
+  original_price: null,
+  category: 'print',
+  badge: null,
+  in_stock: true,
+  featured: false,
+  rating: 4.5,
+  image_url: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  ...overrides,
+})
+
+// ─── HomeProductCard ───────────────────────────────────────────────────────
+describe('HomeProductCard', () => {
+  const defaultProps = {
+    product: makeProduct(),
+    quantity: 0,
+    onAddToCart: jest.fn(),
+    onQuantityChange: jest.fn(),
+    onOpenModal: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders product name, category, and price', () => {
+    render(<HomeProductCard {...defaultProps} />)
+    expect(screen.getByText('Test Print')).toBeInTheDocument()
+    expect(screen.getByText('print')).toBeInTheDocument()
+    expect(screen.getByTestId('price-1')).toHaveTextContent('₦15,000')
+  })
+
+  it('shows Add to Cart button when quantity is 0', () => {
+    render(<HomeProductCard {...defaultProps} />)
+    expect(screen.getByTestId('add-to-cart-1')).toBeInTheDocument()
+    expect(screen.getByText(/add to cart/i)).toBeInTheDocument()
+  })
+
+  it('shows quantity controls when quantity > 0', () => {
+    render(<HomeProductCard {...defaultProps} quantity={2} />)
+    expect(screen.getByTestId('qty-controls-1')).toBeInTheDocument()
+    expect(screen.getByTestId('qty-value-1')).toHaveTextContent('2')
+    expect(screen.getByTestId('qty-minus-1')).toBeInTheDocument()
+    expect(screen.getByTestId('qty-plus-1')).toBeInTheDocument()
+  })
+
+  it('does not show Add to Cart button when quantity > 0', () => {
+    render(<HomeProductCard {...defaultProps} quantity={1} />)
+    expect(screen.queryByTestId('add-to-cart-1')).not.toBeInTheDocument()
+  })
+
+  it('calls onAddToCart when Add to Cart is clicked', () => {
+    const onAddToCart = jest.fn()
+    render(<HomeProductCard {...defaultProps} onAddToCart={onAddToCart} />)
+    fireEvent.click(screen.getByTestId('add-to-cart-1'))
+    expect(onAddToCart).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onQuantityChange with +1 when plus is clicked', () => {
+    const onQuantityChange = jest.fn()
+    render(<HomeProductCard {...defaultProps} quantity={1} onQuantityChange={onQuantityChange} />)
+    fireEvent.click(screen.getByTestId('qty-plus-1'))
+    expect(onQuantityChange).toHaveBeenCalledWith(2)
+  })
+
+  it('calls onQuantityChange with -1 when minus is clicked', () => {
+    const onQuantityChange = jest.fn()
+    render(<HomeProductCard {...defaultProps} quantity={3} onQuantityChange={onQuantityChange} />)
+    fireEvent.click(screen.getByTestId('qty-minus-1'))
+    expect(onQuantityChange).toHaveBeenCalledWith(2)
+  })
+
+  it('calls onOpenModal when card is clicked', () => {
+    const onOpenModal = jest.fn()
+    render(<HomeProductCard {...defaultProps} onOpenModal={onOpenModal} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    expect(onOpenModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents card click when Add to Cart button is clicked', () => {
+    const onAddToCart = jest.fn()
+    const onOpenModal = jest.fn()
+    render(<HomeProductCard {...defaultProps} onAddToCart={onAddToCart} onOpenModal={onOpenModal} />)
+    fireEvent.click(screen.getByTestId('add-to-cart-1'))
+    expect(onAddToCart).toHaveBeenCalledTimes(1)
+    expect(onOpenModal).not.toHaveBeenCalled()
+  })
+
+  it('prevents card click when quantity controls are clicked', () => {
+    const onQuantityChange = jest.fn()
+    const onOpenModal = jest.fn()
+    render(<HomeProductCard {...defaultProps} quantity={1} onQuantityChange={onQuantityChange} onOpenModal={onOpenModal} />)
+    fireEvent.click(screen.getByTestId('qty-plus-1'))
+    expect(onQuantityChange).toHaveBeenCalledWith(2)
+    expect(onOpenModal).not.toHaveBeenCalled()
+  })
+
+  it('shows badge when product has a badge', () => {
+    render(<HomeProductCard {...defaultProps} product={makeProduct({ badge: 'Sale' })} />)
+    expect(screen.getByText('Sale')).toBeInTheDocument()
+  })
+
+  it('shows Out of Stock when product is not in stock', () => {
+    render(<HomeProductCard {...defaultProps} product={makeProduct({ in_stock: false })} />)
+    const outOfStock = screen.getAllByText('Out of Stock')
+    expect(outOfStock.length).toBeGreaterThan(0)
+  })
+
+  it('shows original price with strikethrough when original_price is set', () => {
+    render(<HomeProductCard {...defaultProps} product={makeProduct({ original_price: 20000 })} />)
+    expect(screen.getByText('₦20,000')).toBeInTheDocument()
+  })
+})
+
+// ─── ProductQuickViewModal ─────────────────────────────────────────────────
+describe('ProductQuickViewModal', () => {
+  const defaultProps = {
+    product: makeProduct({ description: 'A nice portrait print on premium paper.' }),
+    quantity: 0,
+    onAddToCart: jest.fn(),
+    onQuantityChange: jest.fn(),
+    onClose: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders product details: name, price, description, category', () => {
+    render(<ProductQuickViewModal {...defaultProps} />)
+    expect(screen.getByTestId('modal-name')).toHaveTextContent('Test Print')
+    expect(screen.getByTestId('modal-price')).toHaveTextContent('₦15,000')
+    expect(screen.getByTestId('modal-description')).toHaveTextContent('A nice portrait print on premium paper.')
+    expect(screen.getByTestId('modal-category')).toHaveTextContent('print')
+  })
+
+  it('shows Add to Cart button when quantity is 0', () => {
+    render(<ProductQuickViewModal {...defaultProps} />)
+    expect(screen.getByTestId('modal-add-to-cart')).toHaveTextContent('Add to Cart')
+  })
+
+  it('shows "Add Another" when quantity > 0', () => {
+    render(<ProductQuickViewModal {...defaultProps} quantity={2} />)
+    expect(screen.getByTestId('modal-add-to-cart')).toHaveTextContent('Add Another')
+  })
+
+  it('shows quantity controls when quantity > 0', () => {
+    render(<ProductQuickViewModal {...defaultProps} quantity={2} />)
+    expect(screen.getByTestId('modal-qty-minus')).toBeInTheDocument()
+    expect(screen.getByTestId('modal-qty-value')).toHaveTextContent('2')
+    expect(screen.getByTestId('modal-qty-plus')).toBeInTheDocument()
+  })
+
+  it('does not show quantity controls when quantity is 0', () => {
+    render(<ProductQuickViewModal {...defaultProps} quantity={0} />)
+    expect(screen.queryByTestId('modal-qty-minus')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('modal-qty-value')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('modal-qty-plus')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('modal-close-btn'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('modal-backdrop'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} onClose={onClose} />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onAddToCart when Add to Cart is clicked', () => {
+    const onAddToCart = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} onAddToCart={onAddToCart} />)
+    fireEvent.click(screen.getByTestId('modal-add-to-cart'))
+    expect(onAddToCart).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onQuantityChange with +1 when plus is clicked', () => {
+    const onQuantityChange = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} quantity={2} onQuantityChange={onQuantityChange} />)
+    fireEvent.click(screen.getByTestId('modal-qty-plus'))
+    expect(onQuantityChange).toHaveBeenCalledWith(3)
+  })
+
+  it('calls onQuantityChange with -1 when minus is clicked', () => {
+    const onQuantityChange = jest.fn()
+    render(<ProductQuickViewModal {...defaultProps} quantity={2} onQuantityChange={onQuantityChange} />)
+    fireEvent.click(screen.getByTestId('modal-qty-minus'))
+    expect(onQuantityChange).toHaveBeenCalledWith(1)
+  })
+
+  it('shows Out of Stock when product is not in stock', () => {
+    render(<ProductQuickViewModal {...defaultProps} product={makeProduct({ in_stock: false })} />)
+    const outOfStock = screen.getAllByText('Out of Stock')
+    expect(outOfStock.length).toBeGreaterThan(0)
+  })
+
+  it('disables add to cart when product is out of stock', () => {
+    render(<ProductQuickViewModal {...defaultProps} product={makeProduct({ in_stock: false })} />)
+    const btn = screen.getByRole('button', { name: /out of stock/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('renders the product image area', () => {
+    render(<ProductQuickViewModal {...defaultProps} />)
+    expect(screen.getByTestId('modal-image')).toBeInTheDocument()
+  })
+
+  it('shows badge in modal when product has badge', () => {
+    render(<ProductQuickViewModal {...defaultProps} product={makeProduct({ badge: 'New' })} />)
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('shows original price with strikethrough in modal', () => {
+    render(<ProductQuickViewModal {...defaultProps} product={makeProduct({ original_price: 20000 })} />)
+    expect(screen.getByText('₦20,000')).toBeInTheDocument()
+  })
+
+  it('shows in stock availability text', () => {
+    render(<ProductQuickViewModal {...defaultProps} />)
+    expect(screen.getByText('In Stock')).toBeInTheDocument()
+  })
+
+  it('sets aria-modal and role attributes', () => {
+    render(<ProductQuickViewModal {...defaultProps} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-label', 'Quick view: Test Print')
+  })
+})
+
+// ─── HomeProductSection (integration) ──────────────────────────────────────
+describe('HomeProductSection', () => {
+  const products: Product[] = [
+    makeProduct({ id: '1', name: 'Portrait Print' }),
+    makeProduct({ id: '2', name: 'Canvas Wrap', category: 'canvas', price: 25000 }),
+    makeProduct({ id: '3', name: 'Out of Stock', in_stock: false }),
+  ]
+
+  let mockCart: {
+    addStoreItem: jest.Mock
+    removeStoreItem: jest.Mock
+    setStoreQuantity: jest.Mock
+    state: {
+      storeItems: Array<{ product: { id: string }; quantity: number }>
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCart = {
+      addStoreItem: jest.fn(),
+      removeStoreItem: jest.fn(),
+      setStoreQuantity: jest.fn(),
+      state: { storeItems: [] },
+    }
+    jest.spyOn(require('@/context/CartContext'), 'useCart').mockReturnValue(mockCart)
+  })
+
+  it('renders all products in the grid', () => {
+    render(<HomeProductSection products={products} />)
+    expect(screen.getByText('Portrait Print')).toBeInTheDocument()
+    expect(screen.getByText('Canvas Wrap')).toBeInTheDocument()
+    const outOfStock = screen.getAllByText('Out of Stock')
+    expect(outOfStock.length).toBeGreaterThan(0)
+  })
+
+  it('renders section heading', () => {
+    render(<HomeProductSection products={products} />)
+    expect(screen.getByText(/art products/i)).toBeInTheDocument()
+  })
+
+  it('has a link to view all products', () => {
+    render(<HomeProductSection products={products} />)
+    expect(screen.getByText(/view all products/i).closest('a')).toHaveAttribute('href', '/store')
+  })
+
+  it('opens modal when a product card is clicked', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    expect(screen.getByTestId('product-quick-view-modal')).toBeInTheDocument()
+  })
+
+  it('modal displays the correct product details', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-2'))
+    expect(screen.getByTestId('modal-name')).toHaveTextContent('Canvas Wrap')
+    expect(screen.getByTestId('modal-price')).toHaveTextContent('₦25,000')
+  })
+
+  it('closes modal when close button is clicked', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    expect(screen.getByTestId('product-quick-view-modal')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('modal-close-btn'))
+    expect(screen.queryByTestId('product-quick-view-modal')).not.toBeInTheDocument()
+  })
+
+  it('closes modal when backdrop is clicked', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    expect(screen.getByTestId('product-quick-view-modal')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('modal-backdrop'))
+    expect(screen.queryByTestId('product-quick-view-modal')).not.toBeInTheDocument()
+  })
+
+  it('calls addStoreItem when Add to Cart is clicked on card', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('add-to-cart-1'))
+    expect(mockCart.addStoreItem).toHaveBeenCalledTimes(1)
+    expect(mockCart.addStoreItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '1', name: 'Portrait Print' })
+    )
+  })
+
+  it('calls addStoreItem when Add to Cart is clicked in modal', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    fireEvent.click(screen.getByTestId('modal-add-to-cart'))
+    expect(mockCart.addStoreItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls removeStoreItem when quantity reaches 0 from card', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 1 }]
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('qty-minus-1'))
+    expect(mockCart.removeStoreItem).toHaveBeenCalledWith('1')
+    expect(mockCart.setStoreQuantity).not.toHaveBeenCalled()
+  })
+
+  it('calls setStoreQuantity when plus is clicked on card', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 1 }]
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('qty-plus-1'))
+    expect(mockCart.setStoreQuantity).toHaveBeenCalledWith('1', 2)
+  })
+
+  it('calls setStoreQuantity when minus is clicked on card above 1', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 3 }]
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('qty-minus-1'))
+    expect(mockCart.setStoreQuantity).toHaveBeenCalledWith('1', 2)
+  })
+
+  it('calls removeStoreItem when quantity reaches 0 from modal', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 1 }]
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    fireEvent.click(screen.getByTestId('modal-qty-minus'))
+    expect(mockCart.removeStoreItem).toHaveBeenCalledWith('1')
+  })
+
+  it('shows quantity on card that matches cart state', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 3 }]
+    render(<HomeProductSection products={products} />)
+    expect(screen.getByTestId('qty-value-1')).toHaveTextContent('3')
+  })
+
+  it('shows Add to Cart on card when item is removed from cart', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 1 }]
+    render(<HomeProductSection products={products} />)
+    expect(screen.getByTestId('qty-controls-1')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('qty-minus-1'))
+    expect(mockCart.removeStoreItem).toHaveBeenCalledWith('1')
+  })
+
+  it('syncs quantity between modal and card when changed in modal', () => {
+    mockCart.state.storeItems = [{ product: { id: '1' }, quantity: 1 }]
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-1'))
+    expect(screen.getByTestId('modal-qty-value')).toHaveTextContent('1')
+    fireEvent.click(screen.getByTestId('modal-qty-plus'))
+    expect(mockCart.setStoreQuantity).toHaveBeenCalledWith('1', 2)
+  })
+
+  it('shows Out of Stock for out-of-stock products', () => {
+    render(<HomeProductSection products={products} />)
+    const outOfStockElements = screen.getAllByText('Out of Stock')
+    expect(outOfStockElements.length).toBeGreaterThan(0)
+  })
+
+  it('does not show modal for out-of-stock product card click', () => {
+    render(<HomeProductSection products={products} />)
+    fireEvent.click(screen.getByTestId('product-card-3'))
+    // Modal should still open for out-of-stock products (user can view details)
+    expect(screen.getByTestId('product-quick-view-modal')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/pages/AdminCustomersContent.test.tsx
+++ b/src/__tests__/pages/AdminCustomersContent.test.tsx
@@ -10,6 +10,9 @@ jest.mock('@/lib/tokens', () => ({
 jest.mock('@/components/ui', () => ({
   StatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
 }))
+jest.mock('@/app/actions/admin', () => ({
+  deleteUser: jest.fn(),
+}))
 
 type Profile = Database['public']['Tables']['profiles']['Row'] & {
   orders: {
@@ -29,7 +32,13 @@ const makeCustomer = (overrides: Partial<Profile> = {}): Profile => ({
   ...overrides,
 })
 
+const mockDeleteUser = jest.mocked(require('@/app/actions/admin').deleteUser)
+
 describe('AdminCustomersContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('shows empty state when no customers', () => {
     render(<AdminCustomersContent customers={[]} />)
     expect(screen.getByText('No customers yet.')).toBeInTheDocument()
@@ -81,6 +90,109 @@ describe('AdminCustomersContent', () => {
   it('shows — for missing phone', () => {
     render(<AdminCustomersContent customers={[makeCustomer({ phone: null })]} />)
     expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  // ── Delete functionality ────────────────────────────────────────────
+
+  it('shows Del button for each customer row', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    expect(screen.getByTestId('delete-user-u1')).toBeInTheDocument()
+  })
+
+  it('shows Delete User button in detail panel', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByText('Jane Doe'))
+    expect(screen.getByTestId('delete-user-panel')).toBeInTheDocument()
+  })
+
+  it('opens confirmation modal when Del button is clicked', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    expect(screen.getByTestId('confirm-delete-modal')).toBeInTheDocument()
+  })
+
+  it('opens confirmation modal from detail panel Delete User button', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByText('Jane Doe'))
+    fireEvent.click(screen.getByTestId('delete-user-panel'))
+    expect(screen.getByTestId('confirm-delete-modal')).toBeInTheDocument()
+  })
+
+  it('confirmation modal shows customer name and email', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    const nameMatches = screen.getAllByText('Jane Doe')
+    expect(nameMatches.length).toBeGreaterThan(0)
+    const emailMatches = screen.getAllByText('jane@test.com')
+    expect(emailMatches.length).toBeGreaterThan(0)
+  })
+
+  it('confirmation modal shows warning message', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    expect(screen.getByText(/this action cannot be undone/i)).toBeInTheDocument()
+  })
+
+  it('closes confirmation modal on cancel', () => {
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    expect(screen.getByTestId('confirm-delete-modal')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('confirm-delete-cancel'))
+    expect(screen.queryByTestId('confirm-delete-modal')).not.toBeInTheDocument()
+  })
+
+  it('calls deleteUser on confirm and removes customer from list', async () => {
+    mockDeleteUser.mockResolvedValue({ success: true })
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    expect(mockDeleteUser).toHaveBeenCalledWith('u1')
+    // Wait for the state update
+    await screen.findByText('No customers yet.')
+    expect(screen.getByText('No customers yet.')).toBeInTheDocument()
+  })
+
+  it('calls deleteUser on confirm and shows success toast', async () => {
+    mockDeleteUser.mockResolvedValue({ success: true })
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    expect(await screen.findByTestId('toast-notification')).toBeInTheDocument()
+    expect(screen.getByText('User deleted successfully.')).toBeInTheDocument()
+  })
+
+  it('shows error in modal when deleteUser fails', async () => {
+    mockDeleteUser.mockResolvedValue({ error: 'Failed to delete user.' })
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    expect(await screen.findByTestId('confirm-delete-error')).toHaveTextContent('Failed to delete user.')
+  })
+
+  it('removes customer from list after successful delete', async () => {
+    mockDeleteUser.mockResolvedValue({ success: true })
+    const customers = [
+      makeCustomer({ id: 'u1', full_name: 'Jane Doe' }),
+      makeCustomer({ id: 'u2', full_name: 'John Smith', orders: [] }),
+    ]
+    render(<AdminCustomersContent customers={customers} />)
+    expect(screen.getByText('2 customers')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('delete-user-u1'))
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    expect(await screen.findByText('John Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+    expect(screen.getByText('1 customers')).toBeInTheDocument()
+  })
+
+  it('closes detail panel when deleted customer was selected', async () => {
+    mockDeleteUser.mockResolvedValue({ success: true })
+    render(<AdminCustomersContent customers={[makeCustomer()]} />)
+    fireEvent.click(screen.getByText('Jane Doe'))
+    expect(screen.getByText('Order History')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('delete-user-panel'))
+    fireEvent.click(screen.getByTestId('confirm-delete-confirm'))
+    await screen.findByText('No customers yet.')
+    expect(screen.queryByText('Order History')).not.toBeInTheDocument()
   })
 })
 

--- a/src/__tests__/pages/AdminOrdersContent.test.tsx
+++ b/src/__tests__/pages/AdminOrdersContent.test.tsx
@@ -14,8 +14,10 @@ jest.mock('@/app/actions/orders', () => ({
   updateOrderStatus: jest.fn().mockResolvedValue({ id: 'o1', status: 'in_progress', payment_status: 'NOT_PAID' }),
 }))
 jest.mock('@/app/actions/uploads', () => ({
-  getAdminUploadsForOrder: jest.fn().mockResolvedValue({ artworkRefs: [], paymentReceipts: [] }),
+  getAdminUploadsForOrder: jest.fn().mockResolvedValue({ items: [], paymentReceipts: [] }),
 }))
+
+const mockGetAdminUploads = jest.requireMock('@/app/actions/uploads').getAdminUploadsForOrder as jest.Mock
 
 type Order = Database['public']['Tables']['orders']['Row'] & {
   profiles?: { id: string; full_name: string; email: string; phone: string | null } | null

--- a/src/app/(public)/_components/HomeProductCard.tsx
+++ b/src/app/(public)/_components/HomeProductCard.tsx
@@ -1,0 +1,109 @@
+'use client'
+import Image from 'next/image'
+import { formatPrice } from '@/lib/tokens'
+import type { Database } from '@/lib/types/database'
+
+type Product = Database['public']['Tables']['products']['Row']
+
+interface HomeProductCardProps {
+  product: Product
+  quantity: number
+  onAddToCart: () => void
+  onQuantityChange: (qty: number) => void
+  onOpenModal: () => void
+}
+
+export default function HomeProductCard({
+  product,
+  quantity,
+  onAddToCart,
+  onQuantityChange,
+  onOpenModal,
+}: HomeProductCardProps) {
+  const inCart = quantity > 0
+
+  return (
+    <div
+      onClick={onOpenModal}
+      data-testid={`product-card-${product.id}`}
+      style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', display: 'flex', flexDirection: 'column', cursor: 'pointer', transition: 'border-color 0.2s, box-shadow 0.2s', position: 'relative' }}
+      className="home-product-card"
+    >
+      <div style={{ height: 200, background: 'var(--bg-dark)', overflow: 'hidden', position: 'relative' }}>
+        {product.image_url ? (
+          <Image src={product.image_url} alt={product.name} fill style={{ objectFit: 'cover', transition: 'transform 0.4s ease' }} sizes="(max-width:540px) 100vw, (max-width:1024px) 50vw, 25vw" className="product-card-image" />
+        ) : (
+          <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <svg width="40" height="40" viewBox="0 0 48 48" fill="none" style={{ opacity: 0.1 }}><rect x="8" y="8" width="32" height="32" stroke="#D4A84B" strokeWidth="1" /></svg>
+          </div>
+        )}
+        {product.badge && (
+          <div style={{ position: 'absolute', top: 10, left: 10, padding: '3px 8px', fontSize: 9, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)' }}>
+            {product.badge}
+          </div>
+        )}
+        {!product.in_stock && (
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
+            Out of Stock
+          </div>
+        )}
+      </div>
+
+      <div style={{ padding: '16px', flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }} onClick={e => e.stopPropagation()}>
+        <div style={{ fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>{product.category}</div>
+        <div style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 17, color: 'var(--text-primary)', lineHeight: 1.2 }}>{product.name}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 'auto', paddingTop: 8 }}>
+          <span style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 18, color: 'var(--gold-light)' }} data-testid={`price-${product.id}`}>
+            {formatPrice(product.price)}
+          </span>
+          {product.original_price && (
+            <span style={{ fontSize: 11, color: 'var(--text-muted)', textDecoration: 'line-through' }}>{formatPrice(product.original_price)}</span>
+          )}
+        </div>
+
+        <div style={{ minHeight: 40, display: 'flex', alignItems: 'center' }}>
+          {product.in_stock ? (
+            inCart ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 0, width: '100%' }} data-testid={`qty-controls-${product.id}`}>
+                <button
+                  onClick={(e) => { e.stopPropagation(); onQuantityChange(quantity - 1) }}
+                  aria-label="Decrease quantity"
+                  data-testid={`qty-minus-${product.id}`}
+                  style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-dark)', border: '1px solid var(--border-color)', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 14, fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  −
+                </button>
+                <div
+                  data-testid={`qty-value-${product.id}`}
+                  style={{ flex: 1, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-card)', borderTop: '1px solid var(--border-color)', borderBottom: '1px solid var(--border-color)', fontSize: 13, fontFamily: '"Libre Franklin",sans-serif', color: 'var(--text-primary)' }}
+                >
+                  {quantity}
+                </div>
+                <button
+                  onClick={(e) => { e.stopPropagation(); onQuantityChange(quantity + 1) }}
+                  aria-label="Increase quantity"
+                  data-testid={`qty-plus-${product.id}`}
+                  style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-dark)', border: '1px solid var(--border-color)', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 14, fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  +
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={(e) => { e.stopPropagation(); onAddToCart() }}
+                data-testid={`add-to-cart-${product.id}`}
+                style={{ width: '100%', padding: '10px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif', transition: 'opacity 0.2s' }}
+              >
+                + Add to Cart
+              </button>
+            )
+          ) : (
+            <div style={{ width: '100%', padding: '10px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'var(--bg-dark)', color: 'var(--text-muted)', border: '1px solid var(--border-color)', textAlign: 'center', fontFamily: '"Libre Franklin",sans-serif' }}>
+              Out of Stock
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/_components/HomeProductSection.tsx
+++ b/src/app/(public)/_components/HomeProductSection.tsx
@@ -1,0 +1,96 @@
+'use client'
+import { useState } from 'react'
+import Link from 'next/link'
+import { SectionTag } from '@/components/ui'
+import { useCart } from '@/context/CartContext'
+import HomeProductCard from './HomeProductCard'
+import ProductQuickViewModal from './ProductQuickViewModal'
+import type { Database } from '@/lib/types/database'
+
+type Product = Database['public']['Tables']['products']['Row']
+
+export default function HomeProductSection({ products }: { products: Product[] }) {
+  const [modalProduct, setModalProduct] = useState<Product | null>(null)
+  const { addStoreItem, removeStoreItem, setStoreQuantity, state } = useCart()
+
+  const getQuantity = (id: string) =>
+    state.storeItems.find(i => i.product.id === id)?.quantity ?? 0
+
+  const handleAddToCart = (p: Product) => {
+    addStoreItem({
+      id: p.id,
+      name: p.name,
+      slug: p.slug,
+      description: p.description ?? '',
+      price: p.price,
+      originalPrice: p.original_price ?? undefined,
+      category: p.category,
+      badge: p.badge ?? undefined,
+      inStock: p.in_stock,
+      featured: p.featured,
+      rating: p.rating,
+    })
+  }
+
+  const handleQuantityChange = (p: Product, qty: number) => {
+    if (qty < 1) {
+      removeStoreItem(p.id)
+    } else {
+      setStoreQuantity(p.id, qty)
+    }
+  }
+
+  return (
+    <section style={{ padding: '100px 0', borderBottom: '1px solid var(--border-color)' }}>
+      <div style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 48, flexWrap: 'wrap', gap: 16 }}>
+          <div>
+            <SectionTag>Store</SectionTag>
+            <h2 style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 'clamp(32px,4vw,52px)' }}>
+              Art Products <span style={{ color: 'var(--gold-light)', fontStyle: 'italic' }}>&amp; Prints</span>
+            </h2>
+          </div>
+          <Link href="/store" style={{ padding: '12px 24px', fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', border: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>
+            View All Products →
+          </Link>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 16 }} className="products-grid">
+          {products.map(p => (
+            <HomeProductCard
+              key={p.id}
+              product={p}
+              quantity={getQuantity(p.id)}
+              onAddToCart={() => handleAddToCart(p)}
+              onQuantityChange={(qty) => handleQuantityChange(p, qty)}
+              onOpenModal={() => setModalProduct(p)}
+            />
+          ))}
+        </div>
+
+        <div style={{ textAlign: 'center', marginTop: 40 }}>
+          <Link href="/store" style={{ display: 'inline-flex', padding: '14px 32px', fontSize: 12, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', border: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>
+            Browse All Products in Store →
+          </Link>
+        </div>
+      </div>
+
+      {modalProduct && (
+        <ProductQuickViewModal
+          product={modalProduct}
+          quantity={getQuantity(modalProduct.id)}
+          onAddToCart={() => handleAddToCart(modalProduct)}
+          onQuantityChange={(qty) => handleQuantityChange(modalProduct, qty)}
+          onClose={() => setModalProduct(null)}
+        />
+      )}
+
+      <style suppressHydrationWarning>{`
+        .home-product-card:hover { border-color: var(--gold-dark) !important; box-shadow: 0 0 0 1px var(--gold-dark) !important; }
+        .home-product-card:hover .product-card-image { transform: scale(1.04) !important; }
+        @media (max-width: 1024px) { .products-grid { grid-template-columns: repeat(2, 1fr) !important; } }
+        @media (max-width: 540px) { .products-grid { grid-template-columns: 1fr !important; } }
+      `}</style>
+    </section>
+  )
+}

--- a/src/app/(public)/_components/ProductQuickViewModal.tsx
+++ b/src/app/(public)/_components/ProductQuickViewModal.tsx
@@ -1,0 +1,204 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import Image from 'next/image'
+import { formatPrice } from '@/lib/tokens'
+import type { Database } from '@/lib/types/database'
+
+type Product = Database['public']['Tables']['products']['Row']
+
+interface ProductQuickViewModalProps {
+  product: Product
+  quantity: number
+  onAddToCart: () => void
+  onQuantityChange: (qty: number) => void
+  onClose: () => void
+}
+
+export default function ProductQuickViewModal({
+  product,
+  quantity,
+  onAddToCart,
+  onQuantityChange,
+  onClose,
+}: ProductQuickViewModalProps) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    closeRef.current?.focus()
+    document.body.style.overflow = 'hidden'
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => {
+      document.body.style.overflow = ''
+      window.removeEventListener('keydown', handler)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Quick view: ${product.name}`}
+      data-testid="product-quick-view-modal"
+      style={{ position: 'fixed', inset: 0, zIndex: 99999, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
+    >
+      <div
+        onClick={onClose}
+        data-testid="modal-backdrop"
+        style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(4px)', cursor: 'pointer' }}
+      />
+
+      <div
+        data-testid="modal-content"
+        style={{
+          position: 'relative',
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border-color)',
+          maxWidth: 720,
+          width: '100%',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          animation: 'quickViewIn 0.25s ease',
+        }}
+        className="quick-view-modal"
+      >
+        <button
+          ref={closeRef}
+          onClick={onClose}
+          aria-label="Close modal"
+          data-testid="modal-close-btn"
+          style={{ position: 'absolute', top: 12, right: 12, zIndex: 2, width: 32, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.5)', border: 'none', color: '#fff', cursor: 'pointer', fontSize: 16, borderRadius: '50%' }}
+        >
+          ✕
+        </button>
+
+        <div style={{ background: 'var(--bg-dark)', minHeight: 320, position: 'relative', overflow: 'hidden' }} data-testid="modal-image">
+          {product.image_url ? (
+            <Image src={product.image_url} alt={product.name} fill style={{ objectFit: 'cover' }} sizes="360px" />
+          ) : (
+            <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <svg width="48" height="48" viewBox="0 0 48 48" fill="none" style={{ opacity: 0.15 }}><rect x="8" y="8" width="32" height="32" stroke="#D4A84B" strokeWidth="1" /></svg>
+            </div>
+          )}
+          {product.badge && (
+            <div style={{ position: 'absolute', top: 12, left: 12, padding: '4px 10px', fontSize: 10, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)' }}>
+              {product.badge}
+            </div>
+          )}
+          {!product.in_stock && (
+            <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
+              Out of Stock
+            </div>
+          )}
+        </div>
+
+        <div style={{ padding: 32, display: 'flex', flexDirection: 'column', gap: 12 }} data-testid="modal-details">
+          <div style={{ fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-muted)' }} data-testid="modal-category">
+            {product.category}
+          </div>
+
+          <h2 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 28, color: 'var(--text-primary)', margin: 0 }} data-testid="modal-name">
+            {product.name}
+          </h2>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 24, color: 'var(--gold-light)' }} data-testid="modal-price">
+              {formatPrice(product.price)}
+            </span>
+            {product.original_price && (
+              <span style={{ fontSize: 13, color: 'var(--text-muted)', textDecoration: 'line-through' }}>
+                {formatPrice(product.original_price)}
+              </span>
+            )}
+          </div>
+
+          {product.description && (
+            <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.8, margin: 0 }} data-testid="modal-description">
+              {product.description}
+            </p>
+          )}
+
+          <div style={{ fontSize: 12, color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ color: 'var(--text-muted)' }}>Availability:</span>
+            {product.in_stock ? (
+              <span style={{ color: 'var(--success)' }}>In Stock</span>
+            ) : (
+              <span style={{ color: 'var(--danger)' }}>Out of Stock</span>
+            )}
+          </div>
+
+          <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 16, marginTop: 'auto', display: 'flex', gap: 10, alignItems: 'center' }}>
+            {product.in_stock && quantity > 0 ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 0 }} data-testid="modal-quantity-controls">
+                <button
+                  onClick={() => onQuantityChange(quantity - 1)}
+                  aria-label="Decrease quantity"
+                  data-testid="modal-qty-minus"
+                  style={{ width: 40, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-dark)', border: '1px solid var(--border-color)', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 16, fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  −
+                </button>
+                <div
+                  data-testid="modal-qty-value"
+                  style={{ width: 48, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-card)', borderTop: '1px solid var(--border-color)', borderBottom: '1px solid var(--border-color)', fontSize: 14, fontFamily: '"Libre Franklin",sans-serif', color: 'var(--text-primary)' }}
+                >
+                  {quantity}
+                </div>
+                <button
+                  onClick={() => onQuantityChange(quantity + 1)}
+                  aria-label="Increase quantity"
+                  data-testid="modal-qty-plus"
+                  style={{ width: 40, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-dark)', border: '1px solid var(--border-color)', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 16, fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  +
+                </button>
+              </div>
+            ) : null}
+
+            {product.in_stock ? (
+              quantity === 0 ? (
+                <button
+                  onClick={onAddToCart}
+                  data-testid="modal-add-to-cart"
+                  style={{ flex: 1, padding: '12px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  Add to Cart
+                </button>
+              ) : (
+                <button
+                  onClick={onAddToCart}
+                  data-testid="modal-add-to-cart"
+                  style={{ flex: 1, padding: '12px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+                >
+                  Add Another
+                </button>
+              )
+            ) : (
+              <button
+                disabled
+                style={{ flex: 1, padding: '12px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'var(--bg-dark)', color: 'var(--text-muted)', border: '1px solid var(--border-color)', cursor: 'not-allowed', fontFamily: '"Libre Franklin",sans-serif' }}
+              >
+                Out of Stock
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <style suppressHydrationWarning>{`
+        @keyframes quickViewIn {
+          from { opacity: 0; transform: scale(0.95) translateY(12px); }
+          to { opacity: 1; transform: scale(1) translateY(0); }
+        }
+        @media (max-width: 700px) {
+          .quick-view-modal { grid-template-columns: 1fr !important; max-height: 85vh !important; }
+          .quick-view-modal > div:first-child { min-height: 200px !important; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -8,8 +8,8 @@ import { getGalleryItems } from '@/app/actions/gallery'
 import { getProducts } from '@/app/actions/products'
 import { getReviews } from '@/app/actions/reviews'
 import { createClient } from '@/lib/supabase/server'
-import { formatPrice } from '@/lib/tokens'
 import type { Database } from '@/lib/types/database'
+import HomeProductSection from '@/app/(public)/_components/HomeProductSection'
 
 type Product = Database['public']['Tables']['products']['Row']
 
@@ -174,44 +174,7 @@ export default async function HomePage() {
       </section>
 
       {/* ── STORE — dynamic, only if admin has added products ─── */}
-      {featuredProducts.length > 0 && (
-        <section style={{ padding: '100px 0', borderBottom: '1px solid var(--border-color)' }}>
-          <div style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px' }}>
-            <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 48, flexWrap: 'wrap', gap: 16 }}>
-              <div><SectionTag>Store</SectionTag><h2 style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 'clamp(32px,4vw,52px)' }}>Art Products <span style={{ color: 'var(--gold-light)', fontStyle: 'italic' }}>&amp; Prints</span></h2></div>
-              <Link href="/store" style={{ padding: '12px 24px', fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', border: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>View All Products →</Link>
-            </div>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 16 }} className="products-grid">
-              {featuredProducts.map(p => (
-                <div key={p.id} style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', display: 'flex', flexDirection: 'column' }}>
-                  <div style={{ height: 200, background: 'var(--bg-dark)', overflow: 'hidden', position: 'relative' }}>
-                    {p.image_url ? (
-                      <Image src={p.image_url} alt={p.name} fill style={{ objectFit: 'cover' }} sizes="(max-width:540px) 100vw, (max-width:1024px) 50vw, 25vw" />
-                    ) : (
-                      <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <svg width="40" height="40" viewBox="0 0 48 48" fill="none" style={{ opacity: 0.1 }}><rect x="8" y="8" width="32" height="32" stroke="#D4A84B" strokeWidth="1" /></svg>
-                      </div>
-                    )}
-                    {p.badge && <div style={{ position: 'absolute', top: 10, left: 10, padding: '3px 8px', fontSize: 9, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', background: 'linear-gradient(135deg,var(--gold-primary),var(--gold-accent))', color: 'var(--text-on-gold)' }}>{p.badge}</div>}
-                  </div>
-                  <div style={{ padding: '16px', flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    <div style={{ fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>{p.category}</div>
-                    <div style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 17, color: 'var(--text-primary)', lineHeight: 1.2 }}>{p.name}</div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 'auto', paddingTop: 8 }}>
-                      <span style={{ fontFamily: '"Cormorant Garamond",serif', fontSize: 18, color: 'var(--gold-light)' }}>{formatPrice(p.price)}</span>
-                      {p.original_price && <span style={{ fontSize: 11, color: 'var(--text-muted)', textDecoration: 'line-through' }}>{formatPrice(p.original_price)}</span>}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div style={{ textAlign: 'center', marginTop: 40 }}>
-              <Link href="/store" style={{ display: 'inline-flex', padding: '14px 32px', fontSize: 12, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', border: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>Browse All Products in Store →</Link>
-            </div>
-          </div>
-          <style>{`@media(max-width:1024px){.products-grid{grid-template-columns:repeat(2,1fr)!important;}}@media(max-width:540px){.products-grid{grid-template-columns:1fr!important;}}`}</style>
-        </section>
-      )}
+      {featuredProducts.length > 0 && <HomeProductSection products={featuredProducts} />}
 
       {/* ── HOW IT WORKS ─────────────────────────────────────── */}
       <section style={{ padding: '100px 0', background: 'var(--bg-card)', borderBottom: '1px solid var(--border-color)' }}>

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { revalidatePath } from 'next/cache'
-import { createAdminClient } from '@/lib/supabase/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
 import { toUserMessage, ERR } from '@/lib/errorMessages'
 
 export async function getAdminStats() {
@@ -45,6 +45,7 @@ export async function getAllCustomers() {
       .from('profiles')
       .select('*')
       .eq('role', 'customer')
+      .not('email', 'like', 'deleted-%@removed')
       .order('created_at', { ascending: false })
     if (error) throw new Error(error.message)
 
@@ -94,5 +95,46 @@ export async function updateOrderPaymentStatus(
   } catch (e) {
     console.error('[updateOrderPaymentStatus]', e instanceof Error ? e.message : e)
     throw new Error(ERR.UPDATE_FAILED)
+  }
+}
+
+export async function deleteUser(userId: string): Promise<{ error: string } | { success: true }> {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { error: ERR.NOT_AUTHENTICATED }
+
+    const { data: callerProfile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single()
+    if (callerProfile?.role !== 'admin') return { error: ERR.PERMISSION_DENIED }
+    if (userId === user.id) return { error: 'You cannot delete your own account.' }
+
+    const admin = createAdminClient()
+
+    const { error: updateError } = await admin
+      .from('profiles')
+      .update({
+        email: `deleted-${userId.slice(0, 8)}@removed`,
+        full_name: 'Deleted User',
+        phone: null,
+      })
+      .eq('id', userId)
+    if (updateError) throw new Error(updateError.message)
+
+    const { error: authError } = await admin.auth.admin.deleteUser(userId)
+    if (authError) {
+      console.error('[deleteUser] Auth deletion failed (profile anonymized):', authError.message)
+    }
+
+    revalidatePath('/admin/customers')
+    revalidatePath('/admin/dashboard')
+
+    return { success: true }
+  } catch (e) {
+    console.error('[deleteUser]', e instanceof Error ? e.message : e)
+    return { error: toUserMessage(e, 'Failed to delete user. Please try again.') }
   }
 }

--- a/src/app/actions/gallery.ts
+++ b/src/app/actions/gallery.ts
@@ -10,6 +10,10 @@ type GalleryUpdate = Database['public']['Tables']['gallery_items']['Update']
 
 export type GalleryItem = GalleryRow
 
+const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp']
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+
 export async function getGalleryItems(options?: { category?: string; featured?: boolean; limit?: number }) {
   const supabase = await createClient()
   let query = supabase
@@ -26,10 +30,7 @@ export async function getGalleryItems(options?: { category?: string; featured?: 
   return data as GalleryItem[]
 }
 
-export async function createGalleryItem(
-  formData: FormData,
-  meta: { title: string; medium: string; size?: string; year: number; category: string; description?: string; featured?: boolean }
-) {
+export async function createGalleryItem(formData: FormData) {
   const admin = createAdminClient()
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -38,23 +39,56 @@ export async function createGalleryItem(
   const file = formData.get('file') as File
   if (!file) throw new Error('No image provided')
 
-  const ext = file.name.split('.').pop()
+  const ext = (file.name.split('.').pop() ?? '').toLowerCase()
+  if (!ALLOWED_EXTENSIONS.includes(ext)) {
+    throw new Error('Unsupported file type. Please upload a JPG, PNG, or WebP image.')
+  }
+  if (file.type && !ALLOWED_MIME_TYPES.includes(file.type)) {
+    throw new Error('Unsupported file type. Please upload a JPG, PNG, or WebP image.')
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    throw new Error('File is too large. Maximum size is 10MB.')
+  }
+
   const storagePath = `gallery/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
 
   const { error: uploadError } = await admin.storage
     .from('gallery-images')
     .upload(storagePath, file, { upsert: false })
-  if (uploadError) throw new Error(uploadError.message)
+  if (uploadError) {
+    console.error('[createGalleryItem] storage upload failed:', uploadError.message)
+    throw new Error('File upload failed. Please try a smaller image (JPG/PNG under 10MB).')
+  }
 
   const { data: urlData } = admin.storage
     .from('gallery-images')
     .getPublicUrl(storagePath)
 
+  // Parse metadata from a FormData field (encoded as JSON string)
+  let meta: {
+    title: string
+    medium?: string
+    size?: string | null
+    year?: number
+    category?: string
+    description?: string | null
+    featured?: boolean
+  } = { title: '' }
+  try {
+    const raw = formData.get('meta')
+    if (typeof raw === 'string') meta = JSON.parse(raw)
+  } catch {
+    console.error('[createGalleryItem] failed to parse meta JSON')
+    throw new Error('Invalid metadata.')
+  }
+  if (!meta.title) throw new Error('Title is required.')
+  if (!meta.category) throw new Error('Category is required.')
+
   const insert: GalleryInsert = {
     title: meta.title,
-    medium: meta.medium,
+    medium: meta.medium ?? 'Pencil on Paper',
     size: meta.size ?? null,
-    year: meta.year,
+    year: meta.year ?? new Date().getFullYear(),
     category: meta.category,
     description: meta.description ?? null,
     featured: meta.featured ?? false,
@@ -67,7 +101,12 @@ export async function createGalleryItem(
     .insert(insert)
     .select()
     .single()
-  if (error) throw new Error(error.message)
+  if (error) {
+    console.error('[createGalleryItem] db insert failed:', error.message)
+    // Clean up the uploaded file if the DB insert fails
+    await admin.storage.from('gallery-images').remove([storagePath]).catch(() => {})
+    throw new Error('Failed to save gallery item. Please try again.')
+  }
   return data as GalleryItem
 }
 

--- a/src/app/actions/uploads.ts
+++ b/src/app/actions/uploads.ts
@@ -113,42 +113,83 @@ export async function getMyUploads() {
   return data as UploadRow[]
 }
 
+type OrderItemRow = Database['public']['Tables']['order_items']['Row']
+type PaymentRow = Database['public']['Tables']['payments']['Row']
+
+/** Fetch uploads linked to a specific order for the current user */
 export async function getUploadsByOrder(orderId: string) {
   const supabase = await createClient()
-  const { data, error } = await supabase
-    .from('uploads')
-    .select('*')
-    .eq('user_id', (await supabase.auth.getUser()).data.user?.id ?? '')
-    .order('created_at', { ascending: false })
-  if (error) return []
-  // Filter by order_item_id linkage or return all user uploads for now
-  return (data ?? []) as UploadRow[]
-}
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
 
-export async function getAdminUploadsForOrder(orderId: string) {
-  const { createAdminClient } = await import('@/lib/supabase/server')
-  const admin = createAdminClient()
-  // Get order items for this order
-  const { data: items } = await admin
+  // Get the user's order items for this order
+  const { data: items } = await supabase
     .from('order_items')
     .select('id')
     .eq('order_id', orderId)
   const itemIds = (items ?? []).map(i => i.id)
+  if (itemIds.length === 0) return []
 
   // Get uploads linked to those items
-  const { data: linked } = itemIds.length > 0
-    ? await admin.from('uploads').select('*').in('order_item_id', itemIds).order('created_at', { ascending: false })
-    : { data: [] }
+  const { data, error } = await supabase
+    .from('uploads')
+    .select('*')
+    .in('order_item_id', itemIds)
+    .order('created_at', { ascending: false })
+  if (error) return []
+  return (data ?? []) as UploadRow[]
+}
 
-  // Also get payment receipts for this order via payments table
+export interface OrderItemWithUploads extends OrderItemRow {
+  uploads: UploadRow[]
+}
+
+export interface AdminOrderUploads {
+  items: OrderItemWithUploads[]
+  paymentReceipts: PaymentRow[]
+}
+
+export async function getAdminUploadsForOrder(orderId: string): Promise<AdminOrderUploads> {
+  const { createAdminClient } = await import('@/lib/supabase/server')
+  const admin = createAdminClient()
+
+  const { data: items } = await admin
+    .from('order_items')
+    .select('*')
+    .eq('order_id', orderId)
+    .order('created_at', { ascending: true })
+  const orderItems = (items ?? []) as OrderItemRow[]
+  const itemIds = orderItems.map(i => i.id)
+
+  // Get uploads linked to those items, keyed by order_item_id
+  let uploadsByItem: Record<string, UploadRow[]> = {}
+  if (itemIds.length > 0) {
+    const { data: linked } = await admin
+      .from('uploads')
+      .select('*')
+      .in('order_item_id', itemIds)
+      .order('created_at', { ascending: false })
+    const uploads = (linked ?? []) as UploadRow[]
+    for (const u of uploads) {
+      if (u.order_item_id) {
+        if (!uploadsByItem[u.order_item_id]) uploadsByItem[u.order_item_id] = []
+        uploadsByItem[u.order_item_id].push(u)
+      }
+    }
+  }
+
+  // Get payment receipts for this order
   const { data: payments } = await admin
     .from('payments')
-    .select('receipt_url, payment_type, amount, status, created_at')
+    .select('*')
     .eq('order_id', orderId)
     .order('created_at', { ascending: true })
 
   return {
-    artworkRefs: (linked ?? []) as UploadRow[],
-    paymentReceipts: (payments ?? []),
+    items: orderItems.map(item => ({
+      ...item,
+      uploads: uploadsByItem[item.id] ?? [],
+    })),
+    paymentReceipts: (payments ?? []) as PaymentRow[],
   }
 }

--- a/src/app/admin/(protected)/customers/AdminCustomersContent.tsx
+++ b/src/app/admin/(protected)/customers/AdminCustomersContent.tsx
@@ -1,7 +1,10 @@
 'use client'
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
 import { formatPrice, formatDate } from '@/lib/tokens'
 import { StatusBadge } from '@/components/ui'
+import ConfirmDeleteModal from '@/components/ui/ConfirmDeleteModal'
+import ToastNotification from '@/components/ui/ToastNotification'
+import { deleteUser } from '@/app/actions/admin'
 import type { Database } from '@/lib/types/database'
 
 type Profile = Database['public']['Tables']['profiles']['Row'] & {
@@ -12,14 +15,39 @@ type Profile = Database['public']['Tables']['profiles']['Row'] & {
   }[]
 }
 
-export default function AdminCustomersContent({ customers }: { customers: Profile[] }) {
+export default function AdminCustomersContent({ customers: initial }: { customers: Profile[] }) {
+  const [customers, setCustomers] = useState(initial)
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<Profile | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Profile | null>(null)
+  const [deleteError, setDeleteError] = useState('')
+  const [toast, setToast] = useState<{ message: string; variant: 'success' | 'error' } | null>(null)
+  const [isPending, startTransition] = useTransition()
 
   const filtered = customers.filter(c =>
     c.full_name.toLowerCase().includes(search.toLowerCase()) ||
     c.email.toLowerCase().includes(search.toLowerCase())
   )
+
+  const handleDelete = () => {
+    if (!deleteTarget) return
+    setDeleteError('')
+    startTransition(async () => {
+      try {
+        const result = await deleteUser(deleteTarget.id)
+        if ('error' in result) {
+          setDeleteError(result.error)
+          return
+        }
+        setCustomers(prev => prev.filter(c => c.id !== deleteTarget.id))
+        if (selected?.id === deleteTarget.id) setSelected(null)
+        setDeleteTarget(null)
+        setToast({ message: 'User deleted successfully.', variant: 'success' })
+      } catch {
+        setDeleteError('Failed to delete user. Please try again.')
+      }
+    })
+  }
 
   return (
     <div style={{ padding: 36, minHeight: '100vh' }} className="admin-customers-page">
@@ -35,21 +63,29 @@ export default function AdminCustomersContent({ customers }: { customers: Profil
 
       <div style={{ display: 'grid', gridTemplateColumns: selected ? '1fr 360px' : '1fr', gap: 24, alignItems: 'start' }} className="customers-layout">
         <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1.5fr 1.5fr 1fr 1fr 1fr', padding: '12px 20px', borderBottom: '1px solid var(--border-color)' }} className="customers-table-head">
-            {['Name', 'Email', 'Phone', 'Orders', 'Joined'].map(h => (
+          <div style={{ display: 'grid', gridTemplateColumns: '1.5fr 1.5fr 1fr 1fr 1fr 60px', padding: '12px 20px', borderBottom: '1px solid var(--border-color)' }} className="customers-table-head">
+            {['Name', 'Email', 'Phone', 'Orders', 'Joined', ''].map(h => (
               <div key={h} style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>{h}</div>
             ))}
           </div>
           {filtered.length === 0 ? (
             <div style={{ padding: '60px 24px', textAlign: 'center', color: 'var(--text-muted)' }}>No customers yet.</div>
           ) : filtered.map(c => (
-            <div key={c.id} onClick={() => setSelected(selected?.id === c.id ? null : c)} style={{ display: 'grid', gridTemplateColumns: '1.5fr 1.5fr 1fr 1fr 1fr', padding: '16px 20px', borderBottom: '1px solid var(--border-color)', alignItems: 'center', cursor: 'pointer', background: selected?.id === c.id ? 'rgba(184,134,11,0.04)' : 'transparent', transition: 'background 0.2s' }} className="customer-row">
-              <div style={{ fontSize: 13, fontWeight: 500 }}>{c.full_name}</div>
-              <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{c.email}</div>
-              <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{c.phone ?? '—'}</div>
-              <div style={{ fontSize: 13, color: 'var(--gold-light)' }}>{c.orders?.length ?? 0}</div>
-              <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{formatDate(c.created_at)}</div>
-              {/* Mobile card meta — shown only on small screens via CSS */}
+            <div key={c.id} className="customer-row" style={{ display: 'grid', gridTemplateColumns: '1.5fr 1.5fr 1fr 1fr 1fr 60px', padding: '16px 20px', borderBottom: '1px solid var(--border-color)', alignItems: 'center', background: selected?.id === c.id ? 'rgba(184,134,11,0.04)' : 'transparent', transition: 'background 0.2s' }}>
+              <div style={{ fontSize: 13, fontWeight: 500, cursor: 'pointer' }} onClick={() => setSelected(selected?.id === c.id ? null : c)}>{c.full_name}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-secondary)', cursor: 'pointer' }} onClick={() => setSelected(selected?.id === c.id ? null : c)}>{c.email}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', cursor: 'pointer' }} onClick={() => setSelected(selected?.id === c.id ? null : c)}>{c.phone ?? '—'}</div>
+              <div style={{ fontSize: 13, color: 'var(--gold-light)', cursor: 'pointer' }} onClick={() => setSelected(selected?.id === c.id ? null : c)}>{c.orders?.length ?? 0}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', cursor: 'pointer' }} onClick={() => setSelected(selected?.id === c.id ? null : c)}>{formatDate(c.created_at)}</div>
+              <button
+                onClick={() => setDeleteTarget(c)}
+                title="Delete user"
+                aria-label={`Delete user ${c.full_name}`}
+                data-testid={`delete-user-${c.id}`}
+                style={{ padding: '4px 8px', fontSize: 11, background: 'transparent', border: '1px solid rgba(220,38,38,0.3)', color: 'var(--danger)', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+              >
+                Del
+              </button>
               <div className="customer-card-meta" style={{ display: 'none', gridColumn: '1 / -1', marginTop: 6, fontSize: 12, color: 'var(--text-secondary)' }}>
                 {c.email} · <span style={{ color: 'var(--gold-light)' }}>{c.orders?.length ?? 0} orders</span>
               </div>
@@ -79,7 +115,7 @@ export default function AdminCustomersContent({ customers }: { customers: Profil
               </div>
 
               {selected.orders && selected.orders.length > 0 && (
-                <div>
+                <div style={{ marginBottom: 24 }}>
                   <div style={{ fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 12 }}>Order History</div>
                   {selected.orders.slice(0, 5).map(o => (
                     <div key={o.id} style={{ padding: '10px 0', borderBottom: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
@@ -95,10 +131,44 @@ export default function AdminCustomersContent({ customers }: { customers: Profil
                   ))}
                 </div>
               )}
+
+              <button
+                onClick={() => setDeleteTarget(selected)}
+                data-testid="delete-user-panel"
+                style={{ width: '100%', padding: '12px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'transparent', border: '1px solid var(--danger)', color: 'var(--danger)', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+              >
+                Delete User
+              </button>
             </div>
           </div>
         )}
       </div>
+
+      {deleteTarget && (
+        <ConfirmDeleteModal
+          title="Delete User"
+          message="Are you sure you want to delete this user? This action cannot be undone."
+          detailLines={[
+            { label: 'Name', value: deleteTarget.full_name },
+            { label: 'Email', value: deleteTarget.email },
+            { label: 'Orders', value: String(deleteTarget.orders?.length ?? 0) },
+            { label: 'Total Spent', value: formatPrice(deleteTarget.orders?.reduce((s, o) => s + o.amount_paid, 0) ?? 0) },
+          ]}
+          confirmLabel="Delete User"
+          onConfirm={handleDelete}
+          onCancel={() => { setDeleteTarget(null); setDeleteError('') }}
+          loading={isPending}
+          error={deleteError}
+        />
+      )}
+
+      {toast && (
+        <ToastNotification
+          message={toast.message}
+          variant={toast.variant}
+          onDismiss={() => setToast(null)}
+        />
+      )}
 
       <style suppressHydrationWarning>{`
         @media (max-width: 700px) {
@@ -106,11 +176,13 @@ export default function AdminCustomersContent({ customers }: { customers: Profil
           .customers-filters { flex-direction: column !important; }
           .customers-layout { grid-template-columns: 1fr !important; }
           .customers-table-head { display: none !important; }
-          .customer-row { grid-template-columns: 1fr !important; padding: 14px 16px !important; }
+          .customer-row { grid-template-columns: 1fr 60px !important; padding: 14px 16px !important; }
+          .customer-row > div:nth-child(1) { grid-column: 1 !important; }
           .customer-row > div:nth-child(2),
           .customer-row > div:nth-child(3),
           .customer-row > div:nth-child(4),
           .customer-row > div:nth-child(5) { display: none !important; }
+          .customer-row > button { grid-column: 2 !important; grid-row: 1 !important; align-self: center !important; }
           .customer-card-meta { display: block !important; }
           .customer-detail-panel { position: static !important; }
         }
@@ -119,7 +191,7 @@ export default function AdminCustomersContent({ customers }: { customers: Profil
           .customers-layout { grid-template-columns: 1fr !important; }
           .customer-detail-panel { position: static !important; }
           .customers-table-head,
-          .customer-row { grid-template-columns: 1.5fr 1.5fr 1fr 1fr !important; }
+          .customer-row { grid-template-columns: 1.5fr 1.5fr 1fr 1fr 60px !important; }
           .customers-table-head > div:nth-child(3),
           .customer-row > div:nth-child(3) { display: none !important; }
         }

--- a/src/app/admin/(protected)/gallery/AdminGalleryContent.tsx
+++ b/src/app/admin/(protected)/gallery/AdminGalleryContent.tsx
@@ -54,15 +54,16 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
         } else {
           const formData = new FormData()
           formData.append('file', file!)
-          const created = await createGalleryItem(formData, {
-            title: draft.title!,
+          formData.append('meta', JSON.stringify({
+            title: draft.title,
             medium: draft.medium ?? 'Pencil on Paper',
-            size: draft.size ?? undefined,
+            size: draft.size || null,
             year: draft.year ?? new Date().getFullYear(),
-            category: draft.category!,
-            description: draft.description ?? undefined,
+            category: draft.category,
+            description: draft.description || null,
             featured: draft.featured ?? false,
-          })
+          }))
+          const created = await createGalleryItem(formData)
           setItems(prev => [created, ...prev])
         }
         closeForm()
@@ -95,7 +96,7 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
   }
 
   return (
-    <div style={{ padding: 36, minHeight: '100vh' }}>
+    <div style={{ padding: 36, minHeight: '100vh' }} className="admin-gallery-page">
       <div style={{ marginBottom: 28, paddingBottom: 20, borderBottom: '1px solid var(--border-color)', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
         <div>
           <div style={{ fontSize: 12, letterSpacing: '0.15em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 8 }}>Admin Panel</div>
@@ -106,7 +107,7 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
 
       {error && <div style={{ marginBottom: 16, padding: '12px 16px', background: 'rgba(220,38,38,0.1)', border: '1px solid rgba(220,38,38,0.3)', color: '#f87171', fontSize: 13 }}>{error}</div>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: showForm ? '1fr 400px' : '1fr', gap: 24, alignItems: 'start' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: showForm ? '1fr 400px' : '1fr', gap: 24, alignItems: 'start' }} className="gallery-layout">
         {/* Gallery grid */}
         <div>
           {items.length === 0 ? (
@@ -116,7 +117,7 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
               <button onClick={openAdd} style={{ padding: '12px 24px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'linear-gradient(135deg, var(--gold-primary), var(--gold-accent))', color: 'var(--text-on-gold)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}>Upload Artwork</button>
             </div>
           ) : (
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 16 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 16 }} className="gallery-grid">
               {items.map(item => (
                 <div key={item.id} style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', overflow: 'hidden' }}>
                   <div style={{ height: 200, position: 'relative', overflow: 'hidden', background: 'var(--bg-dark)' }}>
@@ -142,7 +143,7 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
 
         {/* Upload/Edit form */}
         {showForm && (
-          <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 28, position: 'sticky', top: 24 }}>
+          <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 28, position: 'sticky', top: 24 }} className="gallery-form-panel">
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
               <h3 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 24 }}>{editing ? 'Edit Artwork' : 'Upload Artwork'}</h3>
               <button onClick={closeForm} style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 16 }}>✕</button>
@@ -196,6 +197,22 @@ export default function AdminGalleryContent({ items: initial }: { items: Gallery
           </div>
         )}
       </div>
+
+      <style suppressHydrationWarning>{`
+        @media (max-width: 700px) {
+          .admin-gallery-page { padding: 16px !important; }
+          .gallery-layout { grid-template-columns: 1fr !important; }
+          .gallery-form-panel { position: static !important; max-height: none !important; }
+          .gallery-grid { grid-template-columns: repeat(2, 1fr) !important; gap: 8px !important; }
+          .gallery-grid > div > div:first-child { height: 140px !important; }
+          .gallery-grid > div > div:last-child { padding: 10px 12px !important; }
+        }
+        @media (min-width: 701px) and (max-width: 1024px) {
+          .admin-gallery-page { padding: 20px !important; }
+          .gallery-layout { grid-template-columns: 1fr !important; }
+          .gallery-form-panel { position: static !important; max-height: none !important; }
+        }
+      `}</style>
     </div>
   )
 }

--- a/src/app/admin/(protected)/orders/AdminOrdersContent.tsx
+++ b/src/app/admin/(protected)/orders/AdminOrdersContent.tsx
@@ -3,7 +3,7 @@ import { useState, useTransition } from 'react'
 import { formatPrice, formatDate } from '@/lib/tokens'
 import { StatusBadge } from '@/components/ui'
 import { updateOrderStatus } from '@/app/actions/orders'
-import { getAdminUploadsForOrder } from '@/app/actions/uploads'
+import { getAdminUploadsForOrder, type AdminOrderUploads } from '@/app/actions/uploads'
 import type { Database } from '@/lib/types/database'
 
 type Order = Database['public']['Tables']['orders']['Row'] & {
@@ -15,9 +15,52 @@ const ORDER_STATUSES = ['pending', 'in_progress', 'completed', 'canceled'] as co
 const FILTER_STATUSES = ['All', ...ORDER_STATUSES]
 const PAYMENT_FILTERS = ['All', 'NOT_PAID', 'PARTIALLY_PAID', 'FULLY_PAID']
 
-type UploadData = {
-  artworkRefs: Database['public']['Tables']['uploads']['Row'][]
-  paymentReceipts: { receipt_url: string; payment_type: string; amount: number; status: string; created_at: string }[]
+function ImagePreview({ src, alt }: { src: string; alt: string }) {
+  const [broken, setBroken] = useState(false)
+  const [open, setOpen] = useState(false)
+  if (broken) {
+    return (
+      <div style={{ width: '100%', aspectRatio: '4/3', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-dark)', color: 'var(--text-muted)', fontSize: 11, gap: 4, minHeight: 80 }}>
+        <span style={{ fontSize: 20, opacity: 0.4 }}>🖼</span>
+        <span>Image unavailable</span>
+      </div>
+    )
+  }
+  return (
+    <>
+      <div onClick={() => setOpen(true)} style={{ cursor: 'pointer', position: 'relative' }}>
+        <img
+          src={src}
+          alt={alt}
+          onError={() => setBroken(true)}
+          style={{ width: '100%', aspectRatio: '4/3', objectFit: 'cover', display: 'block', background: 'var(--bg-dark)' }}
+        />
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0, transition: 'opacity 0.2s', background: 'rgba(0,0,0,0.4)', fontSize: 24 }} className="img-hover-preview">🔍</div>
+      </div>
+      {open && (
+        <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 99999, background: 'rgba(0,0,0,0.85)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', padding: 40 }}>
+          <button onClick={() => setOpen(false)} style={{ position: 'absolute', top: 20, right: 24, background: 'none', border: 'none', color: '#fff', fontSize: 28, cursor: 'pointer', zIndex: 10 }}>✕</button>
+          <img src={src} alt={alt} style={{ maxWidth: '100%', maxHeight: '90vh', objectFit: 'contain', borderRadius: 4 }} />
+        </div>
+      )}
+      <style>{`.img-hover-preview:hover { opacity: 1 !important; }`}</style>
+    </>
+  )
+}
+
+function ItemServiceLabel(item: Database['public']['Tables']['order_items']['Row']): string {
+  if (item.item_type === 'store_product') return item.product_id ?? 'Store Product'
+  if (item.artwork_type === 'photo_enlargement') return 'Photo Enlargement'
+  return 'Custom Artwork'
+}
+
+function ItemSizeLabel(item: Database['public']['Tables']['order_items']['Row']): string {
+  const parts: string[] = []
+  if (item.size_label) parts.push(item.size_label)
+  if (item.canvas_option) parts.push(`Canvas: ${item.canvas_option}`)
+  if (item.frame_option) parts.push(`Frame: ${item.frame_option}`)
+  if (item.glass_option) parts.push(`Glass: ${item.glass_option}`)
+  return parts.join(' · ') || '—'
 }
 
 export default function AdminOrdersContent({ orders: initial }: { orders: Order[] }) {
@@ -29,7 +72,7 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
   const [newStatus, setNewStatus] = useState('')
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState('')
-  const [orderUploads, setOrderUploads] = useState<UploadData | null>(null)
+  const [orderUploads, setOrderUploads] = useState<AdminOrderUploads | null>(null)
 
   const filtered = orders.filter(o => {
     const name = o.profiles?.full_name?.toLowerCase() ?? ''
@@ -97,7 +140,7 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
         <div style={{ fontSize: 13, color: 'var(--text-muted)', display: 'flex', alignItems: 'center' }}>{filtered.length} orders</div>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: selected ? '1fr 380px' : '1fr', gap: 24, alignItems: 'start' }} className="orders-layout">
+      <div style={{ display: 'grid', gridTemplateColumns: selected ? '1fr 420px' : '1fr', gap: 24, alignItems: 'start' }} className="orders-layout">
         <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr 1fr 1fr 1fr 1fr', padding: '12px 20px', borderBottom: '1px solid var(--border-color)' }} className="orders-table-head">
             {['Order', 'Customer', 'Total', 'Paid', 'Status', 'Payment'].map(h => (
@@ -117,7 +160,6 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
               <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{formatPrice(order.amount_paid)}</div>
               <StatusBadge status={order.status} />
               <StatusBadge status={order.payment_status} />
-              {/* Mobile card layout — hidden on desktop via CSS */}
               <div className="order-card-meta" style={{ display: 'none', gridColumn: '1 / -1', marginTop: 8, gap: 6, flexWrap: 'wrap' }}>
                 <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{order.profiles?.full_name ?? '—'}</span>
                 <span style={{ fontSize: 12, color: 'var(--gold-light)', fontWeight: 500, marginLeft: 'auto' }}>{formatPrice(order.total_amount)}</span>
@@ -164,31 +206,60 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
                 </button>
               </div>
 
-              {orderUploads && orderUploads.paymentReceipts.length > 0 && (
+              {/* Order Items with Uploaded Images */}
+              {orderUploads && orderUploads.items.length > 0 && (
                 <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 20, marginBottom: 20 }}>
-                  <div style={{ fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 12 }}>Payment Receipts</div>
-                  {orderUploads.paymentReceipts.map((p, i) => (
-                    <div key={i} style={{ marginBottom: 12, border: '1px solid var(--border-color)', overflow: 'hidden' }}>
-                      <a href={p.receipt_url} target="_blank" rel="noopener noreferrer" style={{ display: 'block' }}>
-                        <img src={p.receipt_url} alt={`Receipt ${i + 1}`} onError={e => { (e.target as HTMLImageElement).style.display = 'none' }} style={{ width: '100%', maxHeight: 140, objectFit: 'cover', display: 'block', background: 'var(--bg-dark)' }} />
-                        <div style={{ padding: '8px 12px', background: 'var(--bg-dark)', display: 'flex', justifyContent: 'space-between', fontSize: 11 }}>
-                          <span style={{ color: 'var(--text-muted)' }}>{i === 0 ? (p.payment_type === 'partial' ? '1st · 50% Deposit' : '1st · Full') : '2nd · Balance'} · {formatPrice(p.amount)}</span>
-                          <StatusBadge status={p.status} />
+                  <div style={{ fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 12 }}>Order Items ({orderUploads.items.length})</div>
+                  {orderUploads.items.map((item, idx) => (
+                    <div key={item.id} style={{ marginBottom: 16, border: '1px solid var(--border-color)', overflow: 'hidden' }}>
+                      <div style={{ padding: '10px 14px', background: 'var(--bg-dark)', borderBottom: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <div>
+                          <div style={{ fontSize: 12, fontWeight: 600 }}>#{idx + 1} — {ItemServiceLabel(item)}</div>
+                          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{ItemSizeLabel(item)}</div>
                         </div>
-                      </a>
+                        <div style={{ fontSize: 13, color: 'var(--gold-light)' }}>{formatPrice(item.item_subtotal)}</div>
+                      </div>
+
+                      {item.uploads.length > 0 ? (
+                        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, background: 'var(--border-color)' }}>
+                          {item.uploads.map((u) => (
+                            <div key={u.id} style={{ background: 'var(--bg-card)' }}>
+                              <a href={u.file_url} target="_blank" rel="noopener noreferrer" style={{ display: 'block', textDecoration: 'none' }}>
+                                <ImagePreview src={u.file_url} alt={u.file_name} />
+                              </a>
+                              <div style={{ padding: '6px 10px', fontSize: 10, color: 'var(--text-muted)', borderTop: '1px solid var(--border-color)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{u.file_name}</div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div style={{ padding: '24px 14px', textAlign: 'center', color: 'var(--text-muted)', fontSize: 12 }}>
+                          No reference images uploaded for this item.
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>
               )}
 
-              {orderUploads && orderUploads.artworkRefs.length > 0 && (
-                <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 20 }}>
-                  <div style={{ fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 12 }}>Artwork References</div>
-                  {orderUploads.artworkRefs.map((u, i) => (
-                    <div key={u.id} style={{ marginBottom: 12, border: '1px solid var(--border-color)', overflow: 'hidden' }}>
-                      <a href={u.file_url} target="_blank" rel="noopener noreferrer" style={{ display: 'block' }}>
-                        <img src={u.file_url} alt={`Artwork ref ${i + 1}`} onError={e => { (e.target as HTMLImageElement).style.display = 'none' }} style={{ width: '100%', maxHeight: 140, objectFit: 'cover', display: 'block', background: 'var(--bg-dark)' }} />
-                        <div style={{ padding: '8px 12px', background: 'var(--bg-dark)', fontSize: 11, color: 'var(--text-muted)' }}>{u.file_name}</div>
+              {orderUploads && orderUploads.items.length === 0 && (
+                <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 20, marginBottom: 20 }}>
+                  <div style={{ padding: '24px 14px', textAlign: 'center', color: 'var(--text-muted)', fontSize: 12 }}>
+                    This order has no items.
+                  </div>
+                </div>
+              )}
+
+              {orderUploads && orderUploads.paymentReceipts.length > 0 && (
+                <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 20, marginBottom: 20 }}>
+                  <div style={{ fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 12 }}>Payment Receipts</div>
+                  {orderUploads.paymentReceipts.map((p, i) => (
+                    <div key={p.id} style={{ marginBottom: 12, border: '1px solid var(--border-color)', overflow: 'hidden' }}>
+                      <a href={p.receipt_url} target="_blank" rel="noopener noreferrer" style={{ display: 'block' }}>
+                        <ImagePreview src={p.receipt_url} alt={`Receipt ${i + 1}`} />
+                        <div style={{ padding: '8px 12px', background: 'var(--bg-dark)', display: 'flex', justifyContent: 'space-between', fontSize: 11 }}>
+                          <span style={{ color: 'var(--text-muted)' }}>{i === 0 ? (p.payment_type === 'partial' ? '1st · 50% Deposit' : '1st · Full') : '2nd · Balance'} · {formatPrice(p.amount)}</span>
+                          <StatusBadge status={p.status} />
+                        </div>
                       </a>
                     </div>
                   ))}
@@ -200,16 +271,13 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
       </div>
 
       <style suppressHydrationWarning>{`
-        /* ── Mobile (≤ 700px) ── */
         @media (max-width: 700px) {
           .admin-orders-page { padding: 16px !important; }
           .orders-filters { flex-direction: column !important; }
           .orders-filters input,
           .orders-filters select { width: 100% !important; }
           .orders-layout { grid-template-columns: 1fr !important; }
-          /* Hide desktop table header */
           .orders-table-head { display: none !important; }
-          /* Switch rows to card layout */
           .order-row {
             grid-template-columns: 1fr 1fr !important;
             padding: 14px 16px !important;
@@ -219,17 +287,14 @@ export default function AdminOrdersContent({ orders: initial }: { orders: Order[
           .order-row > div:nth-child(3),
           .order-row > div:nth-child(4) { display: none !important; }
           .order-card-meta { display: flex !important; }
-          /* Detail panel: full-width, not sticky */
           .order-detail-panel { position: static !important; max-height: none !important; }
         }
-        /* ── Tablet (701px – 1024px) ── */
         @media (min-width: 701px) and (max-width: 1024px) {
           .admin-orders-page { padding: 20px !important; }
           .orders-layout { grid-template-columns: 1fr !important; }
           .order-detail-panel { position: static !important; max-height: none !important; }
           .orders-table-head,
           .order-row { grid-template-columns: 1.2fr 1fr 1fr 1fr 1fr !important; }
-          /* Hide "Paid" column on tablet to save space */
           .orders-table-head > div:nth-child(4),
           .order-row > div:nth-child(4) { display: none !important; }
         }

--- a/src/app/admin/(protected)/products/AdminProductsContent.tsx
+++ b/src/app/admin/(protected)/products/AdminProductsContent.tsx
@@ -113,7 +113,7 @@ export default function AdminProductsContent({ products: initial }: { products: 
   }
 
   return (
-    <div style={{ padding: 36, minHeight: '100vh' }}>
+    <div style={{ padding: 36, minHeight: '100vh' }} className="admin-products-page">
       <div style={{ marginBottom: 28, paddingBottom: 20, borderBottom: '1px solid var(--border-color)', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
         <div>
           <div style={{ fontSize: 12, letterSpacing: '0.15em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 8 }}>Admin Panel</div>
@@ -122,15 +122,15 @@ export default function AdminProductsContent({ products: initial }: { products: 
         <button onClick={openAdd} style={{ padding: '12px 24px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'linear-gradient(135deg, var(--gold-primary), var(--gold-accent))', color: 'var(--text-on-gold)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}>+ Add Product</button>
       </div>
 
-      <div style={{ display: 'flex', gap: 12, marginBottom: 24 }}>
+      <div style={{ display: 'flex', gap: 12, marginBottom: 24 }} className="products-filters">
         <input placeholder="Search products…" value={search} onChange={e => setSearch(e.target.value)} style={{ ...inputStyle, flex: 1 }} />
         <div style={{ fontSize: 13, color: 'var(--text-muted)', display: 'flex', alignItems: 'center' }}>{filtered.length} products</div>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: showForm ? '1fr 400px' : '1fr', gap: 24, alignItems: 'start' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: showForm ? '1fr 400px' : '1fr', gap: 24, alignItems: 'start' }} className="products-layout">
         {/* Product table */}
         <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: '60px 2fr 1fr 1fr 80px 80px 100px', padding: '12px 20px', borderBottom: '1px solid var(--border-color)' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '60px 2fr 1fr 1fr 80px 80px 100px', padding: '12px 20px', borderBottom: '1px solid var(--border-color)' }} className="products-table-head">
             {['', 'Product', 'Price', 'Category', 'Stock', 'Featured', 'Actions'].map(h => (
               <div key={h} style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>{h}</div>
             ))}
@@ -138,7 +138,7 @@ export default function AdminProductsContent({ products: initial }: { products: 
           {filtered.length === 0 ? (
             <div style={{ padding: '60px 24px', textAlign: 'center', color: 'var(--text-muted)' }}>No products yet. Add your first product.</div>
           ) : filtered.map(p => (
-            <div key={p.id} style={{ display: 'grid', gridTemplateColumns: '60px 2fr 1fr 1fr 80px 80px 100px', padding: '12px 20px', borderBottom: '1px solid var(--border-color)', alignItems: 'center', background: editing?.id === p.id ? 'rgba(184,134,11,0.04)' : 'transparent' }}>
+            <div key={p.id} style={{ display: 'grid', gridTemplateColumns: '60px 2fr 1fr 1fr 80px 80px 100px', padding: '12px 20px', borderBottom: '1px solid var(--border-color)', alignItems: 'center', background: editing?.id === p.id ? 'rgba(184,134,11,0.04)' : 'transparent' }} className="product-row">
               {/* Thumbnail */}
               <div style={{ width: 48, height: 48, background: 'var(--bg-dark)', border: '1px solid var(--border-color)', overflow: 'hidden', flexShrink: 0, position: 'relative' }}>
                 {p.image_url ? (
@@ -166,13 +166,18 @@ export default function AdminProductsContent({ products: initial }: { products: 
                 <button onClick={() => openEdit(p)} style={{ fontSize: 11, padding: '5px 10px', background: 'transparent', border: '1px solid var(--border-color)', color: 'var(--text-secondary)', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}>Edit</button>
                 <button onClick={() => handleDelete(p.id)} style={{ fontSize: 11, padding: '5px 10px', background: 'transparent', border: '1px solid var(--danger)', color: 'var(--danger)', cursor: 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}>Del</button>
               </div>
+              <div className="product-row-meta" style={{ display: 'none', gridColumn: '1 / -1', marginTop: 6, gap: 8, flexWrap: 'wrap', fontSize: 12, color: 'var(--text-secondary)' }}>
+                <span>{p.category}</span>
+                <span style={{ color: 'var(--gold-light)' }}>{formatPrice(p.price)}</span>
+                <span style={{ color: p.in_stock ? 'var(--success)' : 'var(--danger)' }}>{p.in_stock ? 'In Stock' : 'Out of Stock'}</span>
+              </div>
             </div>
           ))}
         </div>
 
         {/* Add/Edit form */}
         {showForm && (
-          <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 28, position: 'sticky', top: 24, maxHeight: '90vh', overflowY: 'auto' }}>
+          <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 28, position: 'sticky', top: 24, maxHeight: '90vh', overflowY: 'auto' }} className="product-form-panel">
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
               <h3 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 24 }}>{editing ? 'Edit Product' : 'Add Product'}</h3>
               <button onClick={closeForm} style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 16 }}>✕</button>
@@ -232,6 +237,36 @@ export default function AdminProductsContent({ products: initial }: { products: 
           </div>
         )}
       </div>
+
+      <style suppressHydrationWarning>{`
+        @media (max-width: 700px) {
+          .admin-products-page { padding: 16px !important; }
+          .products-filters { flex-direction: column !important; }
+          .products-filters input { width: 100% !important; }
+          .products-layout { grid-template-columns: 1fr !important; }
+          .products-table-head { display: none !important; }
+          .product-row {
+            grid-template-columns: 1fr 1fr !important;
+            padding: 14px 16px !important;
+            gap: 6px 12px;
+          }
+          .product-row > div:nth-child(1) { grid-row: 1 / 2; }
+          .product-row > div:nth-child(2) { grid-column: 2 / -1; }
+          .product-row > div:nth-child(3),
+          .product-row > div:nth-child(4),
+          .product-row > div:nth-child(5),
+          .product-row > div:nth-child(6) { display: none !important; }
+          .product-row-meta { display: flex !important; }
+          .product-form-panel { position: static !important; max-height: none !important; }
+        }
+        @media (min-width: 701px) and (max-width: 1024px) {
+          .admin-products-page { padding: 20px !important; }
+          .products-layout { grid-template-columns: 1fr !important; }
+          .product-form-panel { position: static !important; max-height: none !important; }
+          .product-row { grid-template-columns: 60px 2fr 1fr 1fr 80px 80px !important; }
+          .product-row > div:nth-child(7) { display: none !important; }
+        }
+      `}</style>
     </div>
   )
 }

--- a/src/app/admin/(protected)/settings/AdminSettingsContent.tsx
+++ b/src/app/admin/(protected)/settings/AdminSettingsContent.tsx
@@ -62,14 +62,14 @@ export default function AdminSettingsContent({ user }: { user: Profile | null })
   const tabs = [['profile', '◈ Admin Profile'], ['password', '◇ Change Password'], ['bank', '🏦 Bank Details']] as const
 
   return (
-    <div style={{ padding: 36, minHeight: '100vh' }}>
+    <div style={{ padding: 36, minHeight: '100vh' }} className="admin-settings-page">
       <div style={{ marginBottom: 36, paddingBottom: 24, borderBottom: '1px solid var(--border-color)' }}>
         <div style={{ fontSize: 12, letterSpacing: '0.15em', textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 8 }}>Admin Panel</div>
         <h1 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 40 }}>Settings <span style={{ color: 'var(--gold-light)', fontStyle: 'italic' }}>&amp; Profile</span></h1>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', gap: 32, alignItems: 'start' }}>
-        <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', gap: 32, alignItems: 'start' }} className="settings-layout">
+        <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }} className="settings-sidebar">
           {tabs.map(([key, label]) => (
             <button key={key} onClick={() => setTab(key)} style={{ display: 'block', width: '100%', textAlign: 'left', padding: '16px 20px', fontSize: 13, letterSpacing: '0.06em', background: tab === key ? 'rgba(184,134,11,0.08)' : 'transparent', borderLeft: tab === key ? '2px solid var(--gold-primary)' : '2px solid transparent', color: tab === key ? 'var(--gold-light)' : 'var(--text-secondary)', border: 'none', cursor: 'pointer', fontFamily: '"Libre Franklin", sans-serif', transition: 'all 0.2s', borderBottom: '1px solid var(--border-color)' }}>{label}</button>
           ))}
@@ -80,7 +80,7 @@ export default function AdminSettingsContent({ user }: { user: Profile | null })
           </div>
         </div>
 
-        <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 40 }}>
+        <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', padding: 40 }} className="settings-content">
           {tab === 'profile' && (
             <>
               <h2 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 28, marginBottom: 28 }}>Admin Profile</h2>
@@ -119,7 +119,7 @@ export default function AdminSettingsContent({ user }: { user: Profile | null })
               <p style={{ fontSize: 14, color: 'var(--text-secondary)', marginBottom: 28, lineHeight: 1.7 }}>These are the bank accounts customers transfer payments to.</p>
               <div style={{ display: 'grid', gap: 1, background: 'var(--border-color)' }}>
                 {BANK_DETAILS.map(bank => (
-                  <div key={bank.label} style={{ background: 'var(--bg-dark)', padding: '20px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div key={bank.label} style={{ background: 'var(--bg-dark)', padding: '20px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }} className="settings-bank-row">
                     <div>
                       <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>{bank.label}</div>
                       <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>Dikibo Eric Tamunonenqiyeofori</div>
@@ -132,6 +132,23 @@ export default function AdminSettingsContent({ user }: { user: Profile | null })
           )}
         </div>
       </div>
+
+      <style suppressHydrationWarning>{`
+        @media (max-width: 700px) {
+          .admin-settings-page { padding: 16px !important; }
+          .settings-layout { grid-template-columns: 1fr !important; gap: 16px !important; }
+          .settings-sidebar { display: flex !important; overflow-x: auto; }
+          .settings-sidebar > button,
+          .settings-sidebar > form { flex-shrink: 0; }
+          .settings-sidebar > div { display: none !important; }
+          .settings-content { padding: 24px 16px !important; }
+          .settings-bank-row { flex-direction: column !important; align-items: flex-start !important; gap: 8px !important; }
+        }
+        @media (min-width: 701px) and (max-width: 1024px) {
+          .admin-settings-page { padding: 20px !important; }
+          .settings-layout { gap: 20px !important; }
+        }
+      `}</style>
     </div>
   )
 }

--- a/src/components/ui/ConfirmDeleteModal.tsx
+++ b/src/components/ui/ConfirmDeleteModal.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+export interface ConfirmDeleteModalProps {
+  title: string
+  message: string
+  detailLines: { label: string; value: string }[]
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+  loading?: boolean
+  error?: string
+}
+
+export default function ConfirmDeleteModal({
+  title,
+  message,
+  detailLines,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+  loading = false,
+  error,
+}: ConfirmDeleteModalProps) {
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={title}
+      data-testid="confirm-delete-modal"
+      style={{ position: 'fixed', inset: 0, zIndex: 99999, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
+    >
+      <div
+        onClick={loading ? undefined : onCancel}
+        data-testid="confirm-delete-backdrop"
+        style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(4px)', cursor: loading ? 'not-allowed' : 'pointer' }}
+      />
+
+      <div
+        data-testid="confirm-delete-content"
+        style={{
+          position: 'relative',
+          background: 'var(--bg-card)',
+          border: '1px solid var(--danger)',
+          maxWidth: 460,
+          width: '100%',
+          padding: 40,
+          animation: 'confirmDeleteIn 0.25s ease',
+        }}
+      >
+        <div style={{ fontSize: 36, marginBottom: 12, textAlign: 'center' }}>⚠️</div>
+
+        <h2 style={{ fontFamily: '"Cormorant Garamond", serif', fontSize: 26, color: 'var(--text-primary)', textAlign: 'center', margin: '0 0 8px' }}>
+          {title}
+        </h2>
+
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)', textAlign: 'center', lineHeight: 1.7, margin: '0 0 24px' }}>
+          {message}
+        </p>
+
+        <div style={{ background: 'var(--bg-dark)', border: '1px solid var(--border-color)', padding: 16, marginBottom: 24 }}>
+          {detailLines.map(({ label, value }) => (
+            <div key={label} style={{ display: 'flex', justifyContent: 'space-between', padding: '6px 0', fontSize: 13, gap: 12 }}>
+              <span style={{ color: 'var(--text-muted)', flexShrink: 0 }}>{label}</span>
+              <span style={{ color: 'var(--text-primary)', textAlign: 'right', wordBreak: 'break-word' }}>{value}</span>
+            </div>
+          ))}
+        </div>
+
+        {error && (
+          <div data-testid="confirm-delete-error" style={{ marginBottom: 16, padding: '10px 14px', background: 'rgba(220,38,38,0.1)', border: '1px solid rgba(220,38,38,0.3)', color: '#f87171', fontSize: 12 }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            data-testid="confirm-delete-cancel"
+            style={{ padding: '12px', fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'transparent', border: '1px solid var(--border-color)', color: 'var(--text-secondary)', cursor: loading ? 'not-allowed' : 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            data-testid="confirm-delete-confirm"
+            style={{ padding: '12px', fontSize: 11, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', background: loading ? 'var(--bg-dark)' : 'var(--danger)', color: loading ? 'var(--text-muted)' : '#fff', border: 'none', cursor: loading ? 'not-allowed' : 'pointer', fontFamily: '"Libre Franklin",sans-serif' }}
+          >
+            {loading ? 'Deleting…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+
+      <style suppressHydrationWarning>{`
+        @keyframes confirmDeleteIn {
+          from { opacity: 0; transform: scale(0.95) translateY(12px); }
+          to { opacity: 1; transform: scale(1) translateY(0); }
+        }
+        @media (max-width: 600px) {
+          [data-testid="confirm-delete-modal"] > div:last-child { padding: 24px 16px !important; }
+        }
+      `}</style>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Gallery upload fix**: Refactored `createGalleryItem` to accept single FormData, added server-side file validation, storage cleanup on DB failure
- **Upload-to-order-item linking fix**: Replaced chainable jest.fn() mocks with closure-based query-builder functions to fix interaction with jest.clearAllMocks()
- **Homepage product interactions**: Added interactive product cards with Add to Cart, +/- quantity controls (removes at 0), and product quick-view modal (backdrop blur, Escape key, responsive, ARIA attributes)
- **Admin customer delete**: Added `deleteUser` server action with admin auth check, self-deletion prevention, profile anonymization (soft-delete), confirmation modal with customer details, loading states, toast notifications
- **Mobile responsiveness**: Added responsive `<style>` blocks with mobile/tablet breakpoints to admin Settings and Gallery pages (following Orders/Products pattern)
- **Automated tests**: 49 tests for homepage product interactions, 12 tests for confirmation modal, 11 new delete-flow tests for admin customers

## Testing

- 651 tests pass (1 pre-existing unrelated failure in UserAuth.test.tsx)
- Production build succeeds